### PR TITLE
Use builtin __traits(hasMember, ...) in place of std.traits.hasMember…

### DIFF
--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -277,7 +277,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     alias Representation = T;
 
     // state {
-    static if (hasMember!(Hook, "defaultValue"))
+    static if (__traits(hasMember, Hook, "defaultValue"))
         private T payload = Hook.defaultValue!T;
     else
         private T payload;
@@ -310,7 +310,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     Defines the minimum and maximum. These values are hookable by defining
     `Hook.min` and/or `Hook.max`.
     */
-    static if (hasMember!(Hook, "min"))
+    static if (__traits(hasMember, Hook, "min"))
     {
         enum Checked!(T, Hook) min = Checked!(T, Hook)(Hook.min!T);
         ///
@@ -326,7 +326,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         /// ditto
         enum Checked!(T, Hook) min = Checked(T.min);
     }
-    static if (hasMember!(Hook, "max"))
+    static if (__traits(hasMember, Hook, "max"))
     {
         /// ditto
         enum Checked!(T, Hook) max = Checked(Hook.max!T);
@@ -455,7 +455,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     U opCast(U, this _)()
     if (isIntegral!U || isFloatingPoint!U || is(U == bool))
     {
-        static if (hasMember!(Hook, "hookOpCast"))
+        static if (__traits(hasMember, Hook, "hookOpCast"))
         {
             return hook.hookOpCast!U(payload);
         }
@@ -468,7 +468,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             return payload;
         }
         // may lose bits or precision
-        else static if (!hasMember!(Hook, "onBadCast"))
+        else static if (!__traits(hasMember, Hook, "onBadCast"))
         {
             return cast(U) payload;
         }
@@ -526,11 +526,11 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             {
                 return payload == rhs.payload;
             }
-            else static if (hasMember!(Hook, "hookOpEquals"))
+            else static if (__traits(hasMember, Hook, "hookOpEquals"))
             {
                 return hook.hookOpEquals(payload, rhs.payload);
             }
-            else static if (hasMember!(W, "hookOpEquals"))
+            else static if (__traits(hasMember, W, "hookOpEquals"))
             {
                 return rhs.hook.hookOpEquals(rhs.payload, payload);
             }
@@ -539,7 +539,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
                 return payload == rhs.payload;
             }
         }
-        else static if (hasMember!(Hook, "hookOpEquals"))
+        else static if (__traits(hasMember, Hook, "hookOpEquals"))
             return hook.hookOpEquals(payload, rhs);
         else static if (isIntegral!U || isFloatingPoint!U || is(U == bool))
             return payload == rhs;
@@ -599,13 +599,13 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     */
     size_t toHash() const nothrow @safe
     {
-        static if (hasMember!(Hook, "hookToHash"))
+        static if (__traits(hasMember, Hook, "hookToHash"))
         {
             return hook.hookToHash(payload);
         }
         else static if (stateSize!Hook > 0)
         {
-            static if (hasMember!(typeof(payload), "toHash"))
+            static if (__traits(hasMember, typeof(payload), "toHash"))
             {
                 return payload.toHash() ^ hashOf(hook);
             }
@@ -614,7 +614,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
                 return hashOf(payload) ^ hashOf(hook);
             }
         }
-        else static if (hasMember!(typeof(payload), "toHash"))
+        else static if (__traits(hasMember, typeof(payload), "toHash"))
         {
             return payload.toHash();
         }
@@ -638,13 +638,13 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             alias localPayload = this.payload;
         }
 
-        static if (hasMember!(Hook, "hookToHash"))
+        static if (__traits(hasMember, Hook, "hookToHash"))
         {
             return hook.hookToHash(localPayload);
         }
         else static if (stateSize!Hook > 0)
         {
-            static if (hasMember!(typeof(localPayload), "toHash"))
+            static if (__traits(hasMember, typeof(localPayload), "toHash"))
             {
                 return localPayload.toHash() ^ hashOf(hook);
             }
@@ -653,7 +653,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
                 return hashOf(localPayload) ^ hashOf(hook);
             }
         }
-        else static if (hasMember!(typeof(localPayload), "toHash"))
+        else static if (__traits(hasMember, typeof(localPayload), "toHash"))
         {
             return localPayload.toHash();
         }
@@ -722,7 +722,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     auto opCmp(U, this _)(const U rhs) //const pure @safe nothrow @nogc
     if (isIntegral!U || isFloatingPoint!U || is(U == bool))
     {
-        static if (hasMember!(Hook, "hookOpCmp"))
+        static if (__traits(hasMember, Hook, "hookOpCmp"))
         {
             return hook.hookOpCmp(payload, rhs);
         }
@@ -756,11 +756,11 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             // Use the lhs hook
             return this.opCmp(rhs.payload);
         }
-        else static if (hasMember!(Hook, "hookOpCmp"))
+        else static if (__traits(hasMember, Hook, "hookOpCmp"))
         {
             return hook.hookOpCmp(get, rhs.get);
         }
-        else static if (hasMember!(Hook1, "hookOpCmp"))
+        else static if (__traits(hasMember, Hook1, "hookOpCmp"))
         {
             return -rhs.hook.hookOpCmp(rhs.payload, get);
         }
@@ -852,13 +852,13 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     {
         static if (op == "+")
             return Checked(this); // "+" is not hookable
-        else static if (hasMember!(Hook, "hookOpUnary"))
+        else static if (__traits(hasMember, Hook, "hookOpUnary"))
         {
             auto r = hook.hookOpUnary!op(payload);
             return Checked!(typeof(r), Hook)(r);
         }
         else static if (op == "-" && isIntegral!T && T.sizeof >= 4 &&
-                !isUnsigned!T && hasMember!(Hook, "onOverflow"))
+                !isUnsigned!T && __traits(hasMember, Hook, "onOverflow"))
         {
             static assert(is(typeof(-payload) == typeof(payload)));
             bool overflow;
@@ -875,9 +875,9 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     ref Checked opUnary(string op)() return
     if (op == "++" || op == "--")
     {
-        static if (hasMember!(Hook, "hookOpUnary"))
+        static if (__traits(hasMember, Hook, "hookOpUnary"))
             hook.hookOpUnary!op(payload);
-        else static if (hasMember!(Hook, "onOverflow"))
+        else static if (__traits(hasMember, Hook, "onOverflow"))
         {
             static if (op == "++")
             {
@@ -966,7 +966,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         static if (isIntegral!R) alias Result = Checked!(R, Hook);
         else alias Result = R;
 
-        static if (hasMember!(Hook, "hookOpBinary"))
+        static if (__traits(hasMember, Hook, "hookOpBinary"))
         {
             auto r = hook.hookOpBinary!op(payload, rhs);
             return Checked!(typeof(r), Hook)(r);
@@ -979,7 +979,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         {
             return mixin("payload" ~ op ~ "rhs");
         }
-        else static if (hasMember!(Hook, "onOverflow"))
+        else static if (__traits(hasMember, Hook, "onOverflow"))
         {
             bool overflow;
             auto r = opChecked!op(payload, rhs, overflow);
@@ -1015,23 +1015,23 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             // Delegate to lhs
             return mixin("this" ~ op ~ "rhs.payload");
         }
-        else static if (hasMember!(Hook, "hookOpBinary"))
+        else static if (__traits(hasMember, Hook, "hookOpBinary"))
         {
             return hook.hookOpBinary!op(payload, rhs);
         }
-        else static if (hasMember!(Hook1, "hookOpBinary"))
+        else static if (__traits(hasMember, Hook1, "hookOpBinary"))
         {
             // Delegate to rhs
             return mixin("this.payload" ~ op ~ "rhs");
         }
-        else static if (hasMember!(Hook, "onOverflow") &&
-            !hasMember!(Hook1, "onOverflow"))
+        else static if (__traits(hasMember, Hook, "onOverflow") &&
+            !__traits(hasMember, Hook1, "onOverflow"))
         {
             // Delegate to lhs
             return mixin("this" ~ op ~ "rhs.payload");
         }
-        else static if (hasMember!(Hook1, "onOverflow") &&
-            !hasMember!(Hook, "onOverflow"))
+        else static if (__traits(hasMember, Hook1, "onOverflow") &&
+            !__traits(hasMember, Hook, "onOverflow"))
         {
             // Delegate to rhs
             return mixin("this.payload" ~ op ~ "rhs");
@@ -1096,12 +1096,12 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
 
     private auto opBinaryRightImpl(string op, Lhs, this _)(const Lhs lhs)
     {
-        static if (hasMember!(Hook, "hookOpBinaryRight"))
+        static if (__traits(hasMember, Hook, "hookOpBinaryRight"))
         {
             auto r = hook.hookOpBinaryRight!op(lhs, payload);
             return Checked!(typeof(r), Hook)(r);
         }
-        else static if (hasMember!(Hook, "hookOpBinary"))
+        else static if (__traits(hasMember, Hook, "hookOpBinary"))
         {
             auto r = hook.hookOpBinary!op(lhs, payload);
             return Checked!(typeof(r), Hook)(r);
@@ -1114,7 +1114,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
         {
             return mixin("lhs" ~ op ~ "payload");
         }
-        else static if (hasMember!(Hook, "onOverflow"))
+        else static if (__traits(hasMember, Hook, "onOverflow"))
         {
             bool overflow;
             auto r = opChecked!op(lhs, T(payload), overflow);
@@ -1186,7 +1186,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
     {
         static assert(is(typeof(mixin("payload" ~ op ~ "=rhs")) == T));
 
-        static if (hasMember!(Hook, "hookOpOpAssign"))
+        static if (__traits(hasMember, Hook, "hookOpOpAssign"))
         {
             hook.hookOpOpAssign!op(payload, rhs);
         }
@@ -1197,7 +1197,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
             import std.conv : unsigned;
 
             static if (ProperCompare.hookOpCmp(R.min, min.get) < 0 &&
-                hasMember!(Hook, "onLowerBound"))
+                __traits(hasMember, Hook, "onLowerBound"))
             {
                 if (ProperCompare.hookOpCmp(r, min.get) < 0)
                 {
@@ -1207,7 +1207,7 @@ if (isIntegral!T || is(T == Checked!(U, H), U, H))
                 }
             }
             static if (ProperCompare.hookOpCmp(max.get, R.max) < 0 &&
-                hasMember!(Hook, "onUpperBound"))
+                __traits(hasMember, Hook, "onUpperBound"))
             {
                 if (ProperCompare.hookOpCmp(r, max.get) > 0)
                 {

--- a/std/experimental/allocator/building_blocks/affix_allocator.d
+++ b/std/experimental/allocator/building_blocks/affix_allocator.d
@@ -172,7 +172,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             mixin(_processAndReturnAllocateResult);
         }
 
-        static if (hasMember!(Allocator, "allocateZeroed"))
+        static if (__traits(hasMember, Allocator, "allocateZeroed"))
         package(std) void[] allocateZeroed()(size_t bytes)
         {
             if (!bytes) return null;
@@ -180,7 +180,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             mixin(_processAndReturnAllocateResult);
         }
 
-        static if (hasMember!(Allocator, "allocateAll"))
+        static if (__traits(hasMember, Allocator, "allocateAll"))
         void[] allocateAll()
         {
             auto result = parent.allocateAll();
@@ -209,14 +209,14 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             return result;
         }
 
-        static if (hasMember!(Allocator, "owns"))
+        static if (__traits(hasMember, Allocator, "owns"))
         Ternary owns(void[] b)
         {
             if (b is null) return Ternary.no;
             return parent.owns((() @trusted => actualAllocation(b))());
         }
 
-        static if (hasMember!(Allocator, "resolveInternalPointer"))
+        static if (__traits(hasMember, Allocator, "resolveInternalPointer"))
         Ternary resolveInternalPointer(const void* p, ref void[] result)
         {
             void[] p1;
@@ -230,8 +230,8 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             return Ternary.yes;
         }
 
-        static if (!stateSize!Suffix && hasMember!(Allocator, "expand")
-                    && hasMember!(Allocator, "owns"))
+        static if (!stateSize!Suffix && __traits(hasMember, Allocator, "expand")
+                    && __traits(hasMember, Allocator, "owns"))
         bool expand(ref void[] b, size_t delta)
         {
             if (!b || delta == 0) return delta == 0;
@@ -243,7 +243,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             return true;
         }
 
-        static if (hasMember!(Allocator, "reallocate"))
+        static if (__traits(hasMember, Allocator, "reallocate"))
         bool reallocate(ref void[] b, size_t s)
         {
             if (b is null)
@@ -258,7 +258,7 @@ struct AffixAllocator(Allocator, Prefix, Suffix = void)
             return true;
         }
 
-        static if (hasMember!(Allocator, "deallocate"))
+        static if (__traits(hasMember, Allocator, "deallocate"))
         bool deallocate(void[] b)
         {
             if (!b.ptr) return true;

--- a/std/experimental/allocator/building_blocks/aligned_block_list.d
+++ b/std/experimental/allocator/building_blocks/aligned_block_list.d
@@ -137,7 +137,7 @@ public:
 
     // Since all memory is drawn from ParentAllocator, we can
     // forward this to the parent
-    static if (hasMember!(ParentAllocator, "owns"))
+    static if (__traits(hasMember, ParentAllocator, "owns"))
     Ternary owns(void[] b)
     {
         return parent.owns(b);
@@ -171,7 +171,7 @@ public:
     }
 
     // Allocate works only if memory can be provided via `alignedAllocate` from the parent
-    static if (hasMember!(ParentAllocator, "alignedAllocate"))
+    static if (__traits(hasMember, ParentAllocator, "alignedAllocate"))
     void[] allocate(size_t n)
     {
         static if (isShared)
@@ -327,7 +327,7 @@ struct AlignedBlockList(Allocator, ParentAllocator, ulong theAlignment = (1 << 2
         Returns:
             A chunk of memory of the required length or `null` on failure or
         */
-        static if (hasMember!(ParentAllocator, "alignedAllocate"))
+        static if (__traits(hasMember, ParentAllocator, "alignedAllocate"))
         void[] allocate(size_t n);
 
         /**
@@ -352,7 +352,7 @@ struct AlignedBlockList(Allocator, ParentAllocator, ulong theAlignment = (1 << 2
         Returns:
             `Ternary.yes` if owned by this allocator and `Ternary.no` otherwise
         */
-        static if (hasMember!(ParentAllocator, "owns"))
+        static if (__traits(hasMember, ParentAllocator, "owns"))
         Ternary owns(void[] b);
     }
     else
@@ -487,7 +487,7 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
         Returns:
             A chunk of memory of the required length or `null` on failure or
         */
-        static if (hasMember!(ParentAllocator, "alignedAllocate"))
+        static if (__traits(hasMember, ParentAllocator, "alignedAllocate"))
         void[] allocate(size_t n);
 
         /**
@@ -512,7 +512,7 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
         Returns:
             `Ternary.yes` if owned by this allocator and `Ternary.no` otherwise
         */
-        static if (hasMember!(ParentAllocator, "owns"))
+        static if (__traits(hasMember, ParentAllocator, "owns"))
         Ternary owns(void[] b);
     }
     else

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -151,8 +151,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         factory = plant;
     }
 
-    static if (hasMember!(Allocator, "deallocateAll")
-        && hasMember!(Allocator, "owns"))
+    static if (__traits(hasMember, Allocator, "deallocateAll")
+        && __traits(hasMember, Allocator, "owns"))
     ~this()
     {
         deallocateAll;
@@ -197,7 +197,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         return null;
     }
 
-    static if (hasMember!(Allocator, "allocateZeroed"))
+    static if (__traits(hasMember, Allocator, "allocateZeroed"))
     package(std) void[] allocateZeroed()(size_t s)
     {
         for (auto p = &root, n = *p; n; p = &n.next, n = *p)
@@ -232,7 +232,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     newly created allocator fails, subsequent calls to `alignedAllocate`
     will not cause more calls to `make`.
     */
-    static if (hasMember!(Allocator, "alignedAllocate"))
+    static if (__traits(hasMember, Allocator, "alignedAllocate"))
     void[] alignedAllocate(size_t s, uint theAlignment)
     {
         import std.algorithm.comparison : max;
@@ -313,8 +313,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         // Free the olden buffer
         static if (ouroboros)
         {
-            static if (hasMember!(Allocator, "deallocate")
-                    && hasMember!(Allocator, "owns"))
+            static if (__traits(hasMember, Allocator, "deallocate")
+                    && __traits(hasMember, Allocator, "owns"))
                 deallocate(toFree);
         }
         else
@@ -327,8 +327,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     private Node* addAllocator(size_t atLeastBytes)
     {
         void[] t = allocators;
-        static if (hasMember!(Allocator, "expand")
-            && hasMember!(Allocator, "owns"))
+        static if (__traits(hasMember, Allocator, "expand")
+            && __traits(hasMember, Allocator, "owns"))
         {
             immutable bool expanded = t && this.expand(t, Node.sizeof);
         }
@@ -380,7 +380,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     private Node* addAllocator(size_t atLeastBytes)
     {
         void[] t = allocators;
-        static if (hasMember!(BookkeepingAllocator, "expand"))
+        static if (__traits(hasMember, BookkeepingAllocator, "expand"))
             immutable bool expanded = bkalloc.expand(t, Node.sizeof);
         else
             immutable bool expanded = false;
@@ -425,7 +425,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     `Ternary.unknown` if no allocator returned `Ternary.yes` and at least one
     returned  `Ternary.unknown`.
     */
-    static if (hasMember!(Allocator, "owns"))
+    static if (__traits(hasMember, Allocator, "owns"))
     Ternary owns(void[] b)
     {
         auto result = Ternary.no;
@@ -454,8 +454,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     and calls `expand` for it. The owner is not brought to the head of the
     list.
     */
-    static if (hasMember!(Allocator, "expand")
-        && hasMember!(Allocator, "owns"))
+    static if (__traits(hasMember, Allocator, "expand")
+        && __traits(hasMember, Allocator, "owns"))
     bool expand(ref void[] b, size_t delta)
     {
         if (!b) return delta == 0;
@@ -471,7 +471,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     `b` and calls `reallocate` for it. If that fails, calls the global
     `reallocate`, which allocates a new block and moves memory.
     */
-    static if (hasMember!(Allocator, "reallocate"))
+    static if (__traits(hasMember, Allocator, "reallocate"))
     bool reallocate(ref void[] b, size_t s)
     {
         // First attempt to reallocate within the existing node
@@ -491,8 +491,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     /**
      Defined if `Allocator.deallocate` and `Allocator.owns` are defined.
     */
-    static if (hasMember!(Allocator, "deallocate")
-        && hasMember!(Allocator, "owns"))
+    static if (__traits(hasMember, Allocator, "deallocate")
+        && __traits(hasMember, Allocator, "owns"))
     bool deallocate(void[] b)
     {
         if (!b.ptr) return true;
@@ -534,8 +534,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
     Defined only if `Allocator.owns` and `Allocator.deallocateAll` are
     defined.
     */
-    static if (ouroboros && hasMember!(Allocator, "deallocateAll")
-        && hasMember!(Allocator, "owns"))
+    static if (ouroboros && __traits(hasMember, Allocator, "deallocateAll")
+        && __traits(hasMember, Allocator, "owns"))
     bool deallocateAll()
     {
         Node* special;
@@ -572,8 +572,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         return true;
     }
 
-    static if (!ouroboros && hasMember!(Allocator, "deallocateAll")
-        && hasMember!(Allocator, "owns"))
+    static if (!ouroboros && __traits(hasMember, Allocator, "deallocateAll")
+        && __traits(hasMember, Allocator, "owns"))
     bool deallocateAll()
     {
         foreach (ref n; allocators)
@@ -715,7 +715,7 @@ public:
     fails, subsequent calls to `allocate` will not cause more calls to $(D
     make).
     */
-    static if (hasMember!(typeof(impl), "allocate"))
+    static if (__traits(hasMember, typeof(impl), "allocate"))
     void[] allocate(size_t s)
     {
         lock.lock();
@@ -732,7 +732,7 @@ public:
     newly created allocator fails, subsequent calls to `alignedAllocate`
     will not cause more calls to `make`.
     */
-    static if (hasMember!(typeof(impl), "alignedAllocate"))
+    static if (__traits(hasMember, typeof(impl), "alignedAllocate"))
     void[] alignedAllocate(size_t s, uint a)
     {
         lock.lock();
@@ -744,7 +744,7 @@ public:
     /**
      Defined if `Allocator.deallocate` and `Allocator.owns` are defined.
     */
-    static if (hasMember!(typeof(impl), "deallocate"))
+    static if (__traits(hasMember, typeof(impl), "deallocate"))
     bool deallocate(void[] b)
     {
         lock.lock();
@@ -764,7 +764,7 @@ public:
     `Ternary.unknown` if no allocator returned `Ternary.yes` and at least one
     returned  `Ternary.unknown`.
     */
-    static if (hasMember!(typeof(impl), "owns"))
+    static if (__traits(hasMember, typeof(impl), "owns"))
     Ternary owns(void[] b)
     {
         lock.lock();
@@ -778,7 +778,7 @@ public:
     and calls `expand` for it. The owner is not brought to the head of the
     list.
     */
-    static if (hasMember!(typeof(impl), "expand"))
+    static if (__traits(hasMember, typeof(impl), "expand"))
     bool expand(ref void[] b, size_t delta)
     {
         lock.lock();
@@ -792,7 +792,7 @@ public:
     `b` and calls `reallocate` for it. If that fails, calls the global
     `reallocate`, which allocates a new block and moves memory.
     */
-    static if (hasMember!(typeof(impl), "reallocate"))
+    static if (__traits(hasMember, typeof(impl), "reallocate"))
     bool reallocate(ref void[] b, size_t s)
     {
         lock.lock();
@@ -805,7 +805,7 @@ public:
     Defined only if `Allocator.owns` and `Allocator.deallocateAll` are
     defined.
     */
-    static if (hasMember!(typeof(impl), "deallocateAll"))
+    static if (__traits(hasMember, typeof(impl), "deallocateAll"))
     bool deallocateAll()
     {
         lock.lock();
@@ -818,7 +818,7 @@ public:
      Returns `Ternary.yes` if no allocators are currently active,
     `Ternary.no` otherwise. This methods never returns `Ternary.unknown`.
     */
-    static if (hasMember!(typeof(impl), "empty"))
+    static if (__traits(hasMember, typeof(impl), "empty"))
     Ternary empty()
     {
         lock.lock();

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -193,7 +193,7 @@ private mixin template BitmappedBlockImpl(bool isShared, bool multiBlock)
     }
 
     static if (!is(ParentAllocator == NullAllocator)
-        && hasMember!(ParentAllocator, "deallocate"))
+        && __traits(hasMember, ParentAllocator, "deallocate"))
     ~this()
     {
         // multiblock bitmapped blocks use a BitVector
@@ -1395,7 +1395,7 @@ struct BitmappedBlock(size_t theBlockSize, uint theAlignment = platformAlignment
     import std.traits : hasMember;
     InSituRegion!(10_240, 64) r;
     auto a = BitmappedBlock!(64, 64)(cast(ubyte[])(r.allocateAll()));
-    static assert(hasMember!(InSituRegion!(10_240, 64), "allocateAll"));
+    static assert(__traits(hasMember, InSituRegion!(10_240, 64), "allocateAll"));
     const b = a.allocate(100);
     assert(b.length == 100);
 }
@@ -1732,7 +1732,7 @@ shared struct SharedBitmappedBlock(size_t theBlockSize, uint theAlignment = plat
     InSituRegion!(10_240, 64) r;
     uint blockSize = 64;
     auto a = BitmappedBlock!(chooseAtRuntime, 64)(cast(ubyte[])(r.allocateAll()), blockSize);
-    static assert(hasMember!(InSituRegion!(10_240, 64), "allocateAll"));
+    static assert(__traits(hasMember, InSituRegion!(10_240, 64), "allocateAll"));
     const b = (() pure nothrow @safe @nogc => a.allocate(100))();
     assert(b.length == 100);
 }

--- a/std/experimental/allocator/building_blocks/bucketizer.d
+++ b/std/experimental/allocator/building_blocks/bucketizer.d
@@ -74,7 +74,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
         return null;
     }
 
-    static if (hasMember!(Allocator, "allocateZeroed"))
+    static if (__traits(hasMember, Allocator, "allocateZeroed"))
     package(std) void[] allocateZeroed()(size_t bytes)
     {
         if (!bytes) return null;
@@ -92,7 +92,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     Directs the call to either one of the `buckets` allocators. Defined only
     if `Allocator` defines `alignedAllocate`.
     */
-    static if (hasMember!(Allocator, "alignedAllocate"))
+    static if (__traits(hasMember, Allocator, "alignedAllocate"))
     void[] alignedAllocate(size_t bytes, uint alignment)
     {
         if (!bytes) return null;
@@ -153,7 +153,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     Similar to `reallocate`, with alignment. Defined only if `Allocator`
     defines `alignedReallocate`.
     */
-    static if (hasMember!(Allocator, "alignedReallocate"))
+    static if (__traits(hasMember, Allocator, "alignedReallocate"))
     bool alignedReallocate(ref void[] b, size_t size, uint a)
     {
         if (size == 0)
@@ -179,7 +179,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     /**
     Defined only if `Allocator` defines `owns`. Finds the owner of `b` and forwards the call to it.
     */
-    static if (hasMember!(Allocator, "owns"))
+    static if (__traits(hasMember, Allocator, "owns"))
     Ternary owns(void[] b)
     {
         if (!b.ptr) return Ternary.no;
@@ -194,7 +194,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     /**
     This method is only defined if `Allocator` defines `deallocate`.
     */
-    static if (hasMember!(Allocator, "deallocate"))
+    static if (__traits(hasMember, Allocator, "deallocate"))
     bool deallocate(void[] b)
     {
         if (!b.ptr) return true;
@@ -210,7 +210,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     deallocateAll), and calls it for each bucket in turn. Returns `true` if all
     allocators could deallocate all.
     */
-    static if (hasMember!(Allocator, "deallocateAll"))
+    static if (__traits(hasMember, Allocator, "deallocateAll"))
     bool deallocateAll()
     {
         bool result = true;
@@ -225,7 +225,7 @@ struct Bucketizer(Allocator, size_t min, size_t max, size_t step)
     This method is only defined if all allocators involved define $(D
     resolveInternalPointer), and tries it for each bucket in turn.
     */
-    static if (hasMember!(Allocator, "resolveInternalPointer"))
+    static if (__traits(hasMember, Allocator, "resolveInternalPointer"))
     Ternary resolveInternalPointer(const void* p, ref void[] result)
     {
         foreach (ref a; buckets)

--- a/std/experimental/allocator/building_blocks/fallback_allocator.d
+++ b/std/experimental/allocator/building_blocks/fallback_allocator.d
@@ -68,12 +68,12 @@ struct FallbackAllocator(Primary, Fallback)
         return result.length == s ? result : fallback.allocate(s);
     }
 
-    static if (hasMember!(Primary, "allocateZeroed")
-            || (hasMember!(Fallback, "allocateZeroed")))
+    static if (__traits(hasMember, Primary, "allocateZeroed")
+            || (__traits(hasMember, Fallback, "allocateZeroed")))
     package(std) void[] allocateZeroed()(size_t s)
     {
         // Try to allocate with primary.
-        static if (hasMember!(Primary, "allocateZeroed"))
+        static if (__traits(hasMember, Primary, "allocateZeroed"))
         {
             void[] result = primary.allocateZeroed(s);
             if (result.length == s) return result;
@@ -88,7 +88,7 @@ struct FallbackAllocator(Primary, Fallback)
             }
         }
         // Allocate with fallback.
-        static if (hasMember!(Fallback, "allocateZeroed"))
+        static if (__traits(hasMember, Fallback, "allocateZeroed"))
         {
             return fallback.allocateZeroed(s);
         }
@@ -104,16 +104,16 @@ struct FallbackAllocator(Primary, Fallback)
     `FallbackAllocator` offers `alignedAllocate` iff at least one of the
     allocators also offers it. It attempts to allocate using either or both.
     */
-    static if (hasMember!(Primary, "alignedAllocate")
-        || hasMember!(Fallback, "alignedAllocate"))
+    static if (__traits(hasMember, Primary, "alignedAllocate")
+        || __traits(hasMember, Fallback, "alignedAllocate"))
     void[] alignedAllocate(size_t s, uint a)
     {
-        static if (hasMember!(Primary, "alignedAllocate"))
+        static if (__traits(hasMember, Primary, "alignedAllocate"))
         {{
             auto result = primary.alignedAllocate(s, a);
             if (result.length == s) return result;
         }}
-        static if (hasMember!(Fallback, "alignedAllocate"))
+        static if (__traits(hasMember, Fallback, "alignedAllocate"))
         {{
             auto result = fallback.alignedAllocate(s, a);
             if (result.length == s) return result;
@@ -131,20 +131,20 @@ struct FallbackAllocator(Primary, Fallback)
     (returning `false`) otherwise.
 
     */
-    static if (hasMember!(Primary, "owns")
-        && (hasMember!(Primary, "expand") || hasMember!(Fallback, "expand")))
+    static if (__traits(hasMember, Primary, "owns")
+        && (__traits(hasMember, Primary, "expand") || __traits(hasMember, Fallback, "expand")))
     bool expand(ref void[] b, size_t delta)
     {
         if (!delta) return true;
         if (!b.ptr) return false;
         if (primary.owns(b) == Ternary.yes)
         {
-            static if (hasMember!(Primary, "expand"))
+            static if (__traits(hasMember, Primary, "expand"))
                 return primary.expand(b, delta);
             else
                 return false;
         }
-        static if (hasMember!(Fallback, "expand"))
+        static if (__traits(hasMember, Fallback, "expand"))
             return fallback.expand(b, delta);
         else
             return false;
@@ -161,7 +161,7 @@ struct FallbackAllocator(Primary, Fallback)
     allocation from `fallback` to `primary`.
 
     */
-    static if (hasMember!(Primary, "owns"))
+    static if (__traits(hasMember, Primary, "owns"))
     bool reallocate(ref void[] b, size_t newSize)
     {
         bool crossAllocatorMove(From, To)(ref From from, ref To to)
@@ -170,7 +170,7 @@ struct FallbackAllocator(Primary, Fallback)
             if (b1.length != newSize) return false;
             if (b.length < newSize) b1[0 .. b.length] = b[];
             else b1[] = b[0 .. newSize];
-            static if (hasMember!(From, "deallocate"))
+            static if (__traits(hasMember, From, "deallocate"))
                 from.deallocate(b);
             b = b1;
             return true;
@@ -187,14 +187,14 @@ struct FallbackAllocator(Primary, Fallback)
             || crossAllocatorMove(fallback, primary);
     }
 
-    static if (hasMember!(Primary, "owns")
-        && (hasMember!(Primary, "alignedAllocate")
-            || hasMember!(Fallback, "alignedAllocate")))
+    static if (__traits(hasMember, Primary, "owns")
+        && (__traits(hasMember, Primary, "alignedAllocate")
+            || __traits(hasMember, Fallback, "alignedAllocate")))
     bool alignedReallocate(ref void[] b, size_t newSize, uint a)
     {
         bool crossAllocatorMove(From, To)(ref From from, ref To to)
         {
-            static if (!hasMember!(To, "alignedAllocate"))
+            static if (!__traits(hasMember, To, "alignedAllocate"))
             {
                 return false;
             }
@@ -204,14 +204,14 @@ struct FallbackAllocator(Primary, Fallback)
                 if (b1.length != newSize) return false;
                 if (b.length < newSize) b1[0 .. b.length] = b[];
                 else b1[] = b[0 .. newSize];
-                static if (hasMember!(From, "deallocate"))
+                static if (__traits(hasMember, From, "deallocate"))
                     from.deallocate(b);
                 b = b1;
                 return true;
             }
         }
 
-        static if (hasMember!(Primary, "alignedAllocate"))
+        static if (__traits(hasMember, Primary, "alignedAllocate"))
         {
             if (b is null || primary.owns(b) == Ternary.yes)
             {
@@ -219,7 +219,7 @@ struct FallbackAllocator(Primary, Fallback)
                     || crossAllocatorMove(primary, fallback);
             }
         }
-        static if (hasMember!(Fallback, "alignedAllocate"))
+        static if (__traits(hasMember, Fallback, "alignedAllocate"))
         {
             return fallback.alignedReallocate(b, newSize, a)
                 || crossAllocatorMove(fallback, primary);
@@ -234,7 +234,7 @@ struct FallbackAllocator(Primary, Fallback)
     `owns` is defined if and only if both allocators define `owns`.
     Returns $(D primary.owns(b) | fallback.owns(b)).
     */
-    static if (hasMember!(Primary, "owns") && hasMember!(Fallback, "owns"))
+    static if (__traits(hasMember, Primary, "owns") && __traits(hasMember, Fallback, "owns"))
     Ternary owns(void[] b)
     {
         return primary.owns(b) | fallback.owns(b);
@@ -244,8 +244,8 @@ struct FallbackAllocator(Primary, Fallback)
     `resolveInternalPointer` is defined if and only if both allocators
     define it.
     */
-    static if (hasMember!(Primary, "resolveInternalPointer")
-        && hasMember!(Fallback, "resolveInternalPointer"))
+    static if (__traits(hasMember, Primary, "resolveInternalPointer")
+        && __traits(hasMember, Fallback, "resolveInternalPointer"))
     Ternary resolveInternalPointer(const void* p, ref void[] result)
     {
         Ternary r = primary.resolveInternalPointer(p, result);
@@ -260,21 +260,21 @@ struct FallbackAllocator(Primary, Fallback)
     request is forwarded to `fallback.deallocate` if it is defined, or is a
     no-op otherwise.
     */
-    static if (hasMember!(Primary, "owns") &&
-        (hasMember!(Primary, "deallocate")
-            || hasMember!(Fallback, "deallocate")))
+    static if (__traits(hasMember, Primary, "owns") &&
+        (__traits(hasMember, Primary, "deallocate")
+            || __traits(hasMember, Fallback, "deallocate")))
     bool deallocate(void[] b)
     {
         if (primary.owns(b) == Ternary.yes)
         {
-            static if (hasMember!(Primary, "deallocate"))
+            static if (__traits(hasMember, Primary, "deallocate"))
                 return primary.deallocate(b);
             else
                 return false;
         }
         else
         {
-            static if (hasMember!(Fallback, "deallocate"))
+            static if (__traits(hasMember, Fallback, "deallocate"))
                 return fallback.deallocate(b);
             else
                 return false;
@@ -286,8 +286,8 @@ struct FallbackAllocator(Primary, Fallback)
 
     Returns: $(D primary.empty & fallback.empty)
     */
-    static if (hasMember!(Primary, "empty")
-               && hasMember!(Fallback, "empty"))
+    static if (__traits(hasMember, Primary, "empty")
+               && __traits(hasMember, Fallback, "empty"))
     Ternary empty()
     {
         return primary.empty & fallback.empty;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -333,7 +333,7 @@ struct FreeList(ParentAllocator,
         return parent.allocate(n);
     }
 
-    static if (hasMember!(ParentAllocator, "allocateZeroed"))
+    static if (__traits(hasMember, ParentAllocator, "allocateZeroed"))
     package(std) void[] allocateZeroed()(size_t n)
     {
         static if (adaptive == Yes.adaptive) ++accumSamples;
@@ -384,7 +384,7 @@ struct FreeList(ParentAllocator,
             root.next = t;
             return true;
         }
-        static if (hasMember!(ParentAllocator, "deallocate"))
+        static if (__traits(hasMember, ParentAllocator, "deallocate"))
             return parent.deallocate(block);
         else
             return false;
@@ -394,7 +394,7 @@ struct FreeList(ParentAllocator,
     Defined only if `ParentAllocator` defines `deallocateAll`. If so,
     forwards to it and resets the freelist.
     */
-    static if (hasMember!(ParentAllocator, "deallocateAll"))
+    static if (__traits(hasMember, ParentAllocator, "deallocateAll"))
     bool deallocateAll()
     {
         root = null;
@@ -406,7 +406,7 @@ struct FreeList(ParentAllocator,
     freeing each element in turn. Defined only if `ParentAllocator` defines
     `deallocate`. $(D FreeList!(0, unbounded)) does not have this function.
     */
-    static if (hasMember!(ParentAllocator, "deallocate") && !unchecked)
+    static if (__traits(hasMember, ParentAllocator, "deallocate") && !unchecked)
     void minimize()
     {
         while (root)
@@ -423,7 +423,7 @@ struct FreeList(ParentAllocator,
     on destruction.
     */
     static if (!is(ParentAllocator == NullAllocator) &&
-        hasMember!(ParentAllocator, "deallocate") && !unchecked)
+        __traits(hasMember, ParentAllocator, "deallocate") && !unchecked)
     ~this()
     {
         minimize();
@@ -706,7 +706,7 @@ struct ContiguousFreeList(ParentAllocator,
     Defined if `ParentAllocator` defines it. Checks whether the block
     belongs to this allocator.
     */
-    static if (hasMember!(SParent, "owns") || unchecked)
+    static if (__traits(hasMember, SParent, "owns") || unchecked)
     // Ternary owns(const void[] b) const ?
     Ternary owns(void[] b)
     {
@@ -748,7 +748,7 @@ struct ContiguousFreeList(ParentAllocator,
     /**
     Deallocates everything from the parent.
     */
-    static if (hasMember!(ParentAllocator, "deallocateAll")
+    static if (__traits(hasMember, ParentAllocator, "deallocateAll")
         && stateSize!ParentAllocator)
     bool deallocateAll()
     {
@@ -865,7 +865,7 @@ struct SharedFreeList(ParentAllocator,
     import std.exception : enforce;
     import std.traits : hasMember;
 
-    static if (hasMember!(ParentAllocator, "owns"))
+    static if (__traits(hasMember, ParentAllocator, "owns"))
     {
         import std.typecons : Ternary;
     }
@@ -1042,14 +1042,14 @@ struct SharedFreeList(ParentAllocator,
     }
 
     /// Ditto
-    static if (hasMember!(ParentAllocator, "owns"))
+    static if (__traits(hasMember, ParentAllocator, "owns"))
     Ternary owns(const void[] b) shared const
     {
         return parent.owns(b);
     }
 
     /// Ditto
-    static if (hasMember!(ParentAllocator, "reallocate"))
+    static if (__traits(hasMember, ParentAllocator, "reallocate"))
     bool reallocate(ref void[] b, size_t s) shared
     {
         return parent.reallocate(b, s);
@@ -1098,7 +1098,7 @@ struct SharedFreeList(ParentAllocator,
             lock.unlock();
             return true;
         }
-        static if (hasMember!(ParentAllocator, "deallocate"))
+        static if (__traits(hasMember, ParentAllocator, "deallocate"))
             return parent.deallocate(b);
         else
             return false;
@@ -1110,11 +1110,11 @@ struct SharedFreeList(ParentAllocator,
         bool result = false;
         lock.lock();
         scope(exit) lock.unlock();
-        static if (hasMember!(ParentAllocator, "deallocateAll"))
+        static if (__traits(hasMember, ParentAllocator, "deallocateAll"))
         {
             result = parent.deallocateAll();
         }
-        else static if (hasMember!(ParentAllocator, "deallocate"))
+        else static if (__traits(hasMember, ParentAllocator, "deallocate"))
         {
             result = true;
             for (auto n = _root; n;)
@@ -1135,7 +1135,7 @@ struct SharedFreeList(ParentAllocator,
     freeing each element in turn. Defined only if `ParentAllocator` defines
     `deallocate`.
     */
-    static if (hasMember!(ParentAllocator, "deallocate") && !unchecked)
+    static if (__traits(hasMember, ParentAllocator, "deallocate") && !unchecked)
     void minimize() shared
     {
         lock.lock();

--- a/std/experimental/allocator/building_blocks/free_tree.d
+++ b/std/experimental/allocator/building_blocks/free_tree.d
@@ -256,7 +256,7 @@ struct FreeTree(ParentAllocator)
     The destructor of `FreeTree` releases all memory back to the parent
     allocator.
     */
-    static if (hasMember!(ParentAllocator, "deallocate"))
+    static if (__traits(hasMember, ParentAllocator, "deallocate"))
     ~this()
     {
         clear;
@@ -304,7 +304,7 @@ struct FreeTree(ParentAllocator)
         if (result.ptr) return result.ptr[0 .. n];
 
         // Parent ran out of juice, desperation mode on
-        static if (hasMember!(ParentAllocator, "deallocate"))
+        static if (__traits(hasMember, ParentAllocator, "deallocate"))
         {
             clear;
             // Try parent allocator again.
@@ -380,7 +380,7 @@ struct FreeTree(ParentAllocator)
 
     /** Defined if `ParentAllocator.deallocate` exists, and returns to it
     all memory held in the free tree. */
-    static if (hasMember!(ParentAllocator, "deallocate"))
+    static if (__traits(hasMember, ParentAllocator, "deallocate"))
     void clear()
     {
         void recurse(Node* n)
@@ -401,7 +401,7 @@ struct FreeTree(ParentAllocator)
     stil managed by the free tree).
 
     */
-    static if (hasMember!(ParentAllocator, "deallocateAll"))
+    static if (__traits(hasMember, ParentAllocator, "deallocateAll"))
     bool deallocateAll()
     {
         // This is easy, just nuke the root and deallocate all from the

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -364,7 +364,7 @@ struct KRRegion(ParentAllocator = NullAllocator)
 
     /// Ditto
     static if (!is(ParentAllocator == NullAllocator)
-        && hasMember!(ParentAllocator, "deallocate"))
+        && __traits(hasMember, ParentAllocator, "deallocate"))
     ~this()
     {
         parent.deallocate(payload);

--- a/std/experimental/allocator/building_blocks/quantizer.d
+++ b/std/experimental/allocator/building_blocks/quantizer.d
@@ -82,7 +82,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
         return result.ptr ? result.ptr[0 .. n] : null;
     }
 
-    static if (hasMember!(ParentAllocator, "allocateZeroed"))
+    static if (__traits(hasMember, ParentAllocator, "allocateZeroed"))
     package(std) void[] allocateZeroed()(size_t n)
     {
         auto result = parent.allocateZeroed(goodAllocSize(n));
@@ -94,7 +94,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     `allocate` by forwarding to
     $(D parent.alignedAllocate(goodAllocSize(n), a)).
     */
-    static if (hasMember!(ParentAllocator, "alignedAllocate"))
+    static if (__traits(hasMember, ParentAllocator, "alignedAllocate"))
     void[] alignedAllocate(size_t n, uint a)
     {
         auto result = parent.alignedAllocate(goodAllocSize(n), a);
@@ -124,7 +124,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
             return true;
         }
         // Hail Mary
-        static if (hasMember!(ParentAllocator, "expand"))
+        static if (__traits(hasMember, ParentAllocator, "expand"))
         {
             // Expand to the appropriate quantum
             auto original = (() @trusted => b.ptr[0 .. allocated])();
@@ -176,7 +176,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     occurs in place under the conditions required by `expand`. Shrinking
     occurs in place if $(D goodAllocSize(b.length) == goodAllocSize(s)).
     */
-    static if (hasMember!(ParentAllocator, "alignedAllocate"))
+    static if (__traits(hasMember, ParentAllocator, "alignedAllocate"))
     bool alignedReallocate(ref void[] b, size_t s, uint a)
     {
         if (!b.ptr)
@@ -206,7 +206,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     Defined if `ParentAllocator.deallocate` exists and forwards to
     $(D parent.deallocate(b.ptr[0 .. goodAllocSize(b.length)])).
     */
-    static if (hasMember!(ParentAllocator, "deallocate"))
+    static if (__traits(hasMember, ParentAllocator, "deallocate"))
     bool deallocate(void[] b)
     {
         if (!b.ptr) return true;

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -113,7 +113,7 @@ struct Region(ParentAllocator,
     If `ParentAllocator` defines `deallocate`, the region defines a destructor
     that uses `ParentAllocator.deallocate` to free the memory chunk.
     */
-    static if (hasMember!(ParentAllocator, "deallocate"))
+    static if (__traits(hasMember, ParentAllocator, "deallocate"))
     ~this()
     {
         with (_impl) parent.deallocate(_begin[0 .. _end - _begin]);
@@ -802,7 +802,7 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     Expands an allocated block in place. Expansion will succeed only if the
     block is the last allocated.
     */
-    static if (hasMember!(typeof(_impl), "expand"))
+    static if (__traits(hasMember, typeof(_impl), "expand"))
     bool expand(ref void[] b, size_t delta)
     {
         if (!_impl._current) lazyInit;
@@ -1318,7 +1318,7 @@ shared struct SharedRegion(ParentAllocator,
     If `ParentAllocator` defines `deallocate`, the region defines a destructor
     that uses `ParentAllocator.deallocate` to free the memory chunk.
     */
-    static if (hasMember!(ParentAllocator, "deallocate"))
+    static if (__traits(hasMember, ParentAllocator, "deallocate"))
     ~this()
     {
         with (_impl) parent.deallocate(cast(void[]) _begin[0 .. _end - _begin]);

--- a/std/experimental/allocator/building_blocks/scoped_allocator.d
+++ b/std/experimental/allocator/building_blocks/scoped_allocator.d
@@ -109,7 +109,7 @@ struct ScopedAllocator(ParentAllocator)
         mixin(_processAndReturnAllocateResult);
     }
 
-    static if (hasMember!(Allocator, "allocateZeroed"))
+    static if (__traits(hasMember, Allocator, "allocateZeroed"))
     package(std) void[] allocateZeroed()(size_t n)
     {
         auto b = parent.allocateZeroed(n);
@@ -119,7 +119,7 @@ struct ScopedAllocator(ParentAllocator)
     /**
     Forwards to $(D parent.expand(b, delta)).
     */
-    static if (hasMember!(Allocator, "expand"))
+    static if (__traits(hasMember, Allocator, "expand"))
     bool expand(ref void[] b, size_t delta)
     {
         auto result = parent.expand(b, delta);
@@ -160,7 +160,7 @@ struct ScopedAllocator(ParentAllocator)
     /**
     Forwards to `parent.owns(b)`.
     */
-    static if (hasMember!(Allocator, "owns"))
+    static if (__traits(hasMember, Allocator, "owns"))
     Ternary owns(void[] b)
     {
         return parent.owns(b);
@@ -169,7 +169,7 @@ struct ScopedAllocator(ParentAllocator)
     /**
     Deallocates `b`.
     */
-    static if (hasMember!(Allocator, "deallocate"))
+    static if (__traits(hasMember, Allocator, "deallocate"))
     bool deallocate(void[] b)
     {
         // Remove from list

--- a/std/experimental/allocator/building_blocks/segregator.d
+++ b/std/experimental/allocator/building_blocks/segregator.d
@@ -142,8 +142,8 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             return s <= threshold ? _small.allocate(s) : _large.allocate(s);
         }
 
-        static if (hasMember!(SmallAllocator, "alignedAllocate")
-                && hasMember!(LargeAllocator, "alignedAllocate"))
+        static if (__traits(hasMember, SmallAllocator, "alignedAllocate")
+                && __traits(hasMember, LargeAllocator, "alignedAllocate"))
         void[] alignedAllocate(size_t s, uint a)
         {
             return s <= threshold
@@ -151,15 +151,15 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
                 : _large.alignedAllocate(s, a);
         }
 
-        static if (hasMember!(SmallAllocator, "expand")
-                || hasMember!(LargeAllocator, "expand"))
+        static if (__traits(hasMember, SmallAllocator, "expand")
+                || __traits(hasMember, LargeAllocator, "expand"))
         bool expand(ref void[] b, size_t delta)
         {
             if (!delta) return true;
             if (b.length + delta <= threshold)
             {
                 // Old and new allocations handled by _small
-                static if (hasMember!(SmallAllocator, "expand"))
+                static if (__traits(hasMember, SmallAllocator, "expand"))
                     return _small.expand(b, delta);
                 else
                     return false;
@@ -167,7 +167,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             if (b.length > threshold)
             {
                 // Old and new allocations handled by _large
-                static if (hasMember!(LargeAllocator, "expand"))
+                static if (__traits(hasMember, LargeAllocator, "expand"))
                     return _large.expand(b, delta);
                 else
                     return false;
@@ -176,17 +176,17 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             return false;
         }
 
-        static if (hasMember!(SmallAllocator, "reallocate")
-                || hasMember!(LargeAllocator, "reallocate"))
+        static if (__traits(hasMember, SmallAllocator, "reallocate")
+                || __traits(hasMember, LargeAllocator, "reallocate"))
         bool reallocate(ref void[] b, size_t s)
         {
-            static if (hasMember!(SmallAllocator, "reallocate"))
+            static if (__traits(hasMember, SmallAllocator, "reallocate"))
                 if (b.length <= threshold && s <= threshold)
                 {
                     // Old and new allocations handled by _small
                     return _small.reallocate(b, s);
                 }
-            static if (hasMember!(LargeAllocator, "reallocate"))
+            static if (__traits(hasMember, LargeAllocator, "reallocate"))
                 if (b.length > threshold && s > threshold)
                 {
                     // Old and new allocations handled by _large
@@ -196,17 +196,17 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             return .reallocate(this, b, s);
         }
 
-        static if (hasMember!(SmallAllocator, "alignedReallocate")
-                || hasMember!(LargeAllocator, "alignedReallocate"))
+        static if (__traits(hasMember, SmallAllocator, "alignedReallocate")
+                || __traits(hasMember, LargeAllocator, "alignedReallocate"))
         bool alignedReallocate(ref void[] b, size_t s, uint a)
         {
-            static if (hasMember!(SmallAllocator, "alignedReallocate"))
+            static if (__traits(hasMember, SmallAllocator, "alignedReallocate"))
                 if (b.length <= threshold && s <= threshold)
                 {
                     // Old and new allocations handled by _small
                     return _small.alignedReallocate(b, s, a);
                 }
-            static if (hasMember!(LargeAllocator, "alignedReallocate"))
+            static if (__traits(hasMember, LargeAllocator, "alignedReallocate"))
                 if (b.length > threshold && s > threshold)
                 {
                     // Old and new allocations handled by _large
@@ -216,13 +216,13 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             return .alignedReallocate(this, b, s, a);
         }
 
-        static if (hasMember!(SmallAllocator, "allocateZeroed")
-                || hasMember!(LargeAllocator, "allocateZeroed"))
+        static if (__traits(hasMember, SmallAllocator, "allocateZeroed")
+                || __traits(hasMember, LargeAllocator, "allocateZeroed"))
         package(std) void[] allocateZeroed()(size_t s)
         {
             if (s <= threshold)
             {
-                static if (hasMember!(SmallAllocator, "allocateZeroed"))
+                static if (__traits(hasMember, SmallAllocator, "allocateZeroed"))
                     return _small.allocateZeroed(s);
                 else
                 {
@@ -233,7 +233,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             }
             else
             {
-                static if (hasMember!(LargeAllocator, "allocateZeroed"))
+                static if (__traits(hasMember, LargeAllocator, "allocateZeroed"))
                     return _large.allocateZeroed(s);
                 else
                 {
@@ -244,16 +244,16 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
             }
         }
 
-        static if (hasMember!(SmallAllocator, "owns")
-                && hasMember!(LargeAllocator, "owns"))
+        static if (__traits(hasMember, SmallAllocator, "owns")
+                && __traits(hasMember, LargeAllocator, "owns"))
         Ternary owns(void[] b)
         {
             return Ternary(b.length <= threshold
                 ? _small.owns(b) : _large.owns(b));
         }
 
-        static if (hasMember!(SmallAllocator, "deallocate")
-                && hasMember!(LargeAllocator, "deallocate"))
+        static if (__traits(hasMember, SmallAllocator, "deallocate")
+                && __traits(hasMember, LargeAllocator, "deallocate"))
         bool deallocate(void[] data)
         {
             return data.length <= threshold
@@ -261,23 +261,23 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
                 : _large.deallocate(data);
         }
 
-        static if (hasMember!(SmallAllocator, "deallocateAll")
-                && hasMember!(LargeAllocator, "deallocateAll"))
+        static if (__traits(hasMember, SmallAllocator, "deallocateAll")
+                && __traits(hasMember, LargeAllocator, "deallocateAll"))
         bool deallocateAll()
         {
             // Use & insted of && to evaluate both
             return _small.deallocateAll() & _large.deallocateAll();
         }
 
-        static if (hasMember!(SmallAllocator, "empty")
-                && hasMember!(LargeAllocator, "empty"))
+        static if (__traits(hasMember, SmallAllocator, "empty")
+                && __traits(hasMember, LargeAllocator, "empty"))
         Ternary empty()
         {
             return _small.empty & _large.empty;
         }
 
-        static if (hasMember!(SmallAllocator, "resolveInternalPointer")
-                && hasMember!(LargeAllocator, "resolveInternalPointer"))
+        static if (__traits(hasMember, SmallAllocator, "resolveInternalPointer")
+                && __traits(hasMember, LargeAllocator, "resolveInternalPointer"))
         Ternary resolveInternalPointer(const void* p, ref void[] result)
         {
             Ternary r = _small.resolveInternalPointer(p, result);

--- a/std/experimental/allocator/building_blocks/stats_collector.d
+++ b/std/experimental/allocator/building_blocks/stats_collector.d
@@ -303,7 +303,7 @@ public:
     Increments `numOwns` (per instance and and per call) and forwards to $(D
     parent.owns(b)).
     */
-    static if (hasMember!(Allocator, "owns"))
+    static if (__traits(hasMember, Allocator, "owns"))
     {
         static if ((perCallFlags & Options.numOwns) == 0)
         Ternary owns(void[] b)
@@ -360,7 +360,7 @@ public:
         return result;
     }
 
-    static if (hasMember!(Allocator, "allocateZeroed"))
+    static if (__traits(hasMember, Allocator, "allocateZeroed"))
     {
         static if (!(perCallFlags
             & (Options.numAllocate | Options.numAllocateOK
@@ -410,7 +410,7 @@ public:
     private void[] alignedAllocateImpl(string f = null, ulong n = 0)(size_t bytes, uint a)
     {
         up!"numAlignedAllocate";
-        static if (!hasMember!(Allocator, "alignedAllocate"))
+        static if (!__traits(hasMember, Allocator, "alignedAllocate"))
         {
             if (bytes == 0)
                 up!"numAlignedAllocateOk";
@@ -455,7 +455,7 @@ public:
     {
         up!"numExpand";
         Signed!size_t slack = 0;
-        static if (!hasMember!(Allocator, "expand"))
+        static if (!__traits(hasMember, Allocator, "expand"))
         {
             auto result = s == 0;
         }
@@ -580,13 +580,13 @@ public:
         add!"bytesUsed"(-Signed!size_t(b.length));
         add!"bytesSlack"(-(this.goodAllocSize(b.length) - b.length));
         addPerCall!(f, n, "numDeallocate", "bytesContracted")(1, b.length);
-        static if (hasMember!(Allocator, "deallocate"))
+        static if (__traits(hasMember, Allocator, "deallocate"))
             return parent.deallocate(b);
         else
             return false;
     }
 
-    static if (hasMember!(Allocator, "deallocateAll"))
+    static if (__traits(hasMember, Allocator, "deallocateAll"))
     {
         /**
         Defined only if `Allocator.deallocateAll` is defined. Affects

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -405,7 +405,7 @@ implementation of `reallocate`.
 bool reallocate(Allocator)(ref Allocator a, ref void[] b, size_t s)
 {
     if (b.length == s) return true;
-    static if (hasMember!(Allocator, "expand"))
+    static if (__traits(hasMember, Allocator, "expand"))
     {
         if (b.length <= s && a.expand(b, s - b.length)) return true;
     }
@@ -413,7 +413,7 @@ bool reallocate(Allocator)(ref Allocator a, ref void[] b, size_t s)
     if (newB.length != s) return false;
     if (newB.length <= b.length) newB[] = b[0 .. newB.length];
     else newB[0 .. b.length] = b[];
-    static if (hasMember!(Allocator, "deallocate"))
+    static if (__traits(hasMember, Allocator, "deallocate"))
         a.deallocate(b);
     b = newB;
     return true;
@@ -435,9 +435,9 @@ implementation of `reallocate`.
 */
 bool alignedReallocate(Allocator)(ref Allocator alloc,
         ref void[] b, size_t s, uint a)
-if (hasMember!(Allocator, "alignedAllocate"))
+if (__traits(hasMember, Allocator, "alignedAllocate"))
 {
-    static if (hasMember!(Allocator, "expand"))
+    static if (__traits(hasMember, Allocator, "expand"))
     {
         if (b.length <= s && b.ptr.alignedAt(a)
             && alloc.expand(b, s - b.length)) return true;
@@ -450,7 +450,7 @@ if (hasMember!(Allocator, "alignedAllocate"))
     if (newB.length != s) return false;
     if (newB.length <= b.length) newB[] = b[0 .. newB.length];
     else newB[0 .. b.length] = b[];
-    static if (hasMember!(Allocator, "deallocate"))
+    static if (__traits(hasMember, Allocator, "deallocate"))
         alloc.deallocate(b);
     b = newB;
     return true;
@@ -522,7 +522,7 @@ Forwards each of the methods in `funs` (if defined) to `member`.
     foreach (fun; funs)
     {
         result ~= "
-    static if (hasMember!(typeof("~member~"), `"~fun~"`))
+    static if (__traits(hasMember, typeof("~member~"), `"~fun~"`))
     auto ref "~fun~"(Parameters!(typeof("~member~"."~fun~")) args)
     {
         return "~member~"."~fun~"(args);
@@ -564,7 +564,7 @@ version (StdUnittest)
         assert(b2.ptr + b2.length <= b1.ptr || b1.ptr + b1.length <= b2.ptr);
 
         // Test allocateZeroed
-        static if (hasMember!(A, "allocateZeroed"))
+        static if (__traits(hasMember, A, "allocateZeroed"))
         {{
             auto b3 = a.allocateZeroed(8);
             if (b3 !is null)
@@ -576,26 +576,26 @@ version (StdUnittest)
         }}
 
         // Test alignedAllocate
-        static if (hasMember!(A, "alignedAllocate"))
+        static if (__traits(hasMember, A, "alignedAllocate"))
         {{
              auto b3 = a.alignedAllocate(1, 256);
              assert(b3.length <= 1);
              assert(b3.ptr.alignedAt(256));
              assert(a.alignedReallocate(b3, 2, 512));
              assert(b3.ptr.alignedAt(512));
-             static if (hasMember!(A, "alignedDeallocate"))
+             static if (__traits(hasMember, A, "alignedDeallocate"))
              {
                  a.alignedDeallocate(b3);
              }
          }}
         else
         {
-            static assert(!hasMember!(A, "alignedDeallocate"));
+            static assert(!__traits(hasMember, A, "alignedDeallocate"));
             // This seems to be a bug in the compiler:
-            //static assert(!hasMember!(A, "alignedReallocate"), A.stringof);
+            //static assert(!__traits(hasMember, A, "alignedReallocate"), A.stringof);
         }
 
-        static if (hasMember!(A, "allocateAll"))
+        static if (__traits(hasMember, A, "allocateAll"))
         {{
              auto aa = make();
              if (aa.allocateAll().ptr)
@@ -610,7 +610,7 @@ version (StdUnittest)
              assert(!ab.allocate(1).ptr);
          }}
 
-        static if (hasMember!(A, "expand"))
+        static if (__traits(hasMember, A, "expand"))
         {{
              assert(a.expand(b1, 0));
              auto len = b1.length;
@@ -635,7 +635,7 @@ version (StdUnittest)
         assert(b6.length == 2);
 
         // Test owns
-        static if (hasMember!(A, "owns"))
+        static if (__traits(hasMember, A, "owns"))
         {{
              assert(a.owns(null) == Ternary.no);
              assert(a.owns(b1) == Ternary.yes);
@@ -643,7 +643,7 @@ version (StdUnittest)
              assert(a.owns(b6) == Ternary.yes);
          }}
 
-        static if (hasMember!(A, "resolveInternalPointer"))
+        static if (__traits(hasMember, A, "resolveInternalPointer"))
         {{
              void[] p;
              assert(a.resolveInternalPointer(null, p) == Ternary.no);

--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -1593,7 +1593,7 @@ T[] makeArray(T, Allocator)(auto ref Allocator alloc, size_t length)
         if (overflow) return null;
     }
 
-    static if (__traits(isZeroInit, T) && hasMember!(Allocator, "allocateZeroed"))
+    static if (__traits(isZeroInit, T) && __traits(hasMember, Allocator, "allocateZeroed"))
     {
         auto m = alloc.allocateZeroed(nAlloc);
         return (() @trusted => cast(T[]) m)();
@@ -2699,7 +2699,7 @@ if (!isPointer!A)
         auto state = a.allocate(stateSize!(CAllocatorImpl!A));
         import std.algorithm.mutation : move;
         import std.traits : hasMember;
-        static if (hasMember!(A, "deallocate"))
+        static if (__traits(hasMember, A, "deallocate"))
         {
             scope(failure) a.deallocate(state);
         }
@@ -2716,7 +2716,7 @@ RCIAllocator allocatorObject(A)(A* pa)
     import core.lifetime : emplace;
     auto state = pa.allocate(stateSize!(CAllocatorImpl!(A, Yes.indirect)));
     import std.traits : hasMember;
-    static if (hasMember!(A, "deallocate"))
+    static if (__traits(hasMember, A, "deallocate"))
     {
         scope(failure) pa.deallocate(state);
     }
@@ -2813,7 +2813,7 @@ if (!isPointer!A)
         auto state = a.allocate(stateSize!(CSharedAllocatorImpl!A));
         import std.algorithm.mutation : move;
         import std.traits : hasMember;
-        static if (hasMember!(A, "deallocate"))
+        static if (__traits(hasMember, A, "deallocate"))
         {
             scope(failure) a.deallocate(state);
         }
@@ -2834,7 +2834,7 @@ RCISharedAllocator sharedAllocatorObject(A)(A* pa)
     import core.lifetime : emplace;
     auto state = pa.allocate(stateSize!(CSharedAllocatorImpl!(A, Yes.indirect)));
     import std.traits : hasMember;
-    static if (hasMember!(A, "deallocate"))
+    static if (__traits(hasMember, A, "deallocate"))
     {
         scope(failure) pa.deallocate(state);
     }
@@ -2912,7 +2912,7 @@ nothrow:
     */
     override void[] alignedAllocate(size_t s, uint a)
     {
-        static if (hasMember!(Allocator, "alignedAllocate"))
+        static if (__traits(hasMember, Allocator, "alignedAllocate"))
             return impl.alignedAllocate(s, a);
         else
             return null;
@@ -2924,14 +2924,14 @@ nothrow:
     */
     override Ternary owns(void[] b)
     {
-        static if (hasMember!(Allocator, "owns")) return impl.owns(b);
+        static if (__traits(hasMember, Allocator, "owns")) return impl.owns(b);
         else return Ternary.unknown;
     }
 
     /// Returns $(D impl.expand(b, s)) if defined, `false` otherwise.
     override bool expand(ref void[] b, size_t s)
     {
-        static if (hasMember!(Allocator, "expand"))
+        static if (__traits(hasMember, Allocator, "expand"))
             return impl.expand(b, s);
         else
             return s == 0;
@@ -2946,7 +2946,7 @@ nothrow:
     /// Forwards to `impl.alignedReallocate` if defined, `false` otherwise.
     bool alignedReallocate(ref void[] b, size_t s, uint a)
     {
-        static if (!hasMember!(Allocator, "alignedAllocate"))
+        static if (!__traits(hasMember, Allocator, "alignedAllocate"))
         {
             return false;
         }
@@ -2959,7 +2959,7 @@ nothrow:
     // Undocumented for now
     Ternary resolveInternalPointer(const void* p, ref void[] result)
     {
-        static if (hasMember!(Allocator, "resolveInternalPointer"))
+        static if (__traits(hasMember, Allocator, "resolveInternalPointer"))
         {
             return impl.resolveInternalPointer(p, result);
         }
@@ -2975,7 +2975,7 @@ nothrow:
     */
     override bool deallocate(void[] b)
     {
-        static if (hasMember!(Allocator, "deallocate"))
+        static if (__traits(hasMember, Allocator, "deallocate"))
         {
             return impl.deallocate(b);
         }
@@ -2991,7 +2991,7 @@ nothrow:
     */
     override bool deallocateAll()
     {
-        static if (hasMember!(Allocator, "deallocateAll"))
+        static if (__traits(hasMember, Allocator, "deallocateAll"))
         {
             return impl.deallocateAll();
         }
@@ -3006,7 +3006,7 @@ nothrow:
     */
     override Ternary empty()
     {
-        static if (hasMember!(Allocator, "empty"))
+        static if (__traits(hasMember, Allocator, "empty"))
         {
             return Ternary(impl.empty);
         }
@@ -3021,7 +3021,7 @@ nothrow:
     */
     override void[] allocateAll()
     {
-        static if (hasMember!(Allocator, "allocateAll"))
+        static if (__traits(hasMember, Allocator, "allocateAll"))
         {
             return impl.allocateAll();
         }
@@ -3142,7 +3142,7 @@ nothrow:
     */
     override void[] alignedAllocate(size_t s, uint a) shared
     {
-        static if (hasMember!(Allocator, "alignedAllocate"))
+        static if (__traits(hasMember, Allocator, "alignedAllocate"))
             return impl.alignedAllocate(s, a);
         else
             return null;
@@ -3154,14 +3154,14 @@ nothrow:
     */
     override Ternary owns(void[] b) shared
     {
-        static if (hasMember!(Allocator, "owns")) return impl.owns(b);
+        static if (__traits(hasMember, Allocator, "owns")) return impl.owns(b);
         else return Ternary.unknown;
     }
 
     /// Returns $(D impl.expand(b, s)) if defined, `false` otherwise.
     override bool expand(ref void[] b, size_t s) shared
     {
-        static if (hasMember!(Allocator, "expand"))
+        static if (__traits(hasMember, Allocator, "expand"))
             return impl.expand(b, s);
         else
             return s == 0;
@@ -3176,7 +3176,7 @@ nothrow:
     /// Forwards to `impl.alignedReallocate` if defined, `false` otherwise.
     bool alignedReallocate(ref void[] b, size_t s, uint a) shared
     {
-        static if (!hasMember!(Allocator, "alignedAllocate"))
+        static if (!__traits(hasMember, Allocator, "alignedAllocate"))
         {
             return false;
         }
@@ -3189,7 +3189,7 @@ nothrow:
     // Undocumented for now
     Ternary resolveInternalPointer(const void* p, ref void[] result) shared
     {
-        static if (hasMember!(Allocator, "resolveInternalPointer"))
+        static if (__traits(hasMember, Allocator, "resolveInternalPointer"))
         {
             return impl.resolveInternalPointer(p, result);
         }
@@ -3205,7 +3205,7 @@ nothrow:
     */
     override bool deallocate(void[] b) shared
     {
-        static if (hasMember!(Allocator, "deallocate"))
+        static if (__traits(hasMember, Allocator, "deallocate"))
         {
             return impl.deallocate(b);
         }
@@ -3221,7 +3221,7 @@ nothrow:
     */
     override bool deallocateAll() shared
     {
-        static if (hasMember!(Allocator, "deallocateAll"))
+        static if (__traits(hasMember, Allocator, "deallocateAll"))
         {
             return impl.deallocateAll();
         }
@@ -3236,7 +3236,7 @@ nothrow:
     */
     override Ternary empty() shared
     {
-        static if (hasMember!(Allocator, "empty"))
+        static if (__traits(hasMember, Allocator, "empty"))
         {
             return Ternary(impl.empty);
         }
@@ -3251,7 +3251,7 @@ nothrow:
     */
     override void[] allocateAll() shared
     {
-        static if (hasMember!(Allocator, "allocateAll"))
+        static if (__traits(hasMember, Allocator, "allocateAll"))
         {
             return impl.allocateAll();
         }
@@ -3659,7 +3659,7 @@ private struct InternalPointersTree(Allocator)
     }
 
     /// Ditto
-    static if (hasMember!(Allocator, "reallocate"))
+    static if (__traits(hasMember, Allocator, "reallocate"))
     bool reallocate(ref void[] b, size_t s)
     {
         auto n = &parent.prefix(b);

--- a/std/experimental/allocator/showcase.d
+++ b/std/experimental/allocator/showcase.d
@@ -22,7 +22,7 @@ then falls back to `Allocator`. Defined as:
 alias StackFront(size_t stackSize, Allocator) =
     FallbackAllocator!(
         InSituRegion!(stackSize, Allocator.alignment,
-            hasMember!(Allocator, "deallocate")
+            __traits(hasMember, Allocator, "deallocate")
                 ? Yes.defineDeallocate
                 : No.defineDeallocate),
         Allocator);

--- a/std/range/primitives.d
+++ b/std/range/primitives.d
@@ -296,9 +296,9 @@ guarantees that no more than a single element will be placed.
 private void doPut(R, E)(ref R r, auto ref E e)
 {
     static if (is(PointerTarget!R == struct))
-        enum usingPut = hasMember!(PointerTarget!R, "put");
+        enum usingPut = __traits(hasMember, PointerTarget!R, "put");
     else
-        enum usingPut = hasMember!(R, "put");
+        enum usingPut = __traits(hasMember, R, "put");
 
     static if (usingPut)
     {

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -2371,7 +2371,7 @@ if (is(T == class) || is(T == interface) || isAssociativeArray!T)
     void opAssign(return scope T another) pure nothrow @nogc
     {
         // If `T` defines `opCast` we must infer the safety
-        static if (hasMember!(T, "opCast"))
+        static if (__traits(hasMember, T, "opCast"))
         {
             // This will allow the compiler to infer the safety of `T.opCast!U`
             // without generating any runtime cost
@@ -3899,7 +3899,7 @@ struct Nullable(T)
         assert(e != 12);
     }
 
-    static if (!isAggregateType!T || hasMember!(T, "toHash"))
+    static if (!isAggregateType!T || __traits(hasMember, T, "toHash"))
     {
         size_t toHash() const @safe nothrow
         {


### PR DESCRIPTION
…!(...) to reduce template bloat