### PR TITLE
Remove void CTFE init in emptyOrderedObject to avoid -fastdfa compila…

### DIFF
--- a/std/json.d
+++ b/std/json.d
@@ -724,7 +724,7 @@ struct JSONValue
      * Unlike `emptyObject`, the order of inserted keys is preserved.
      */
     enum emptyOrderedObject = {
-        JSONValue v = void;
+        JSONValue v = void; // See https://github.com/dlang/phobos/pull/10617
         v.orderedObject = null;
         return v;
     }();


### PR DESCRIPTION
…tion error. FYI, @rikkimax has confirmed that this is a true positive.

Compiling with `-fastdfa` outputs the error message

`Expression reads from an uninitialized variable, it must be written to at least once before reading`

for the line

```d
v.orderedObject = null;
```

at https://github.com/dlang/phobos/pull/11020/changes#diff-d1fb4e1375fa4d5b55575641ebca9a783d21d499cda466ebbecae852f4a2a794R728.