### PR TITLE
std.net.curl: fix maxRedirects() interpretation of uint.max

### DIFF
--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -3234,7 +3234,7 @@ struct HTTP
     */
     @property void maxRedirects(uint maxRedirs)
     {
-        if (maxRedirs == uint.max)
+        if (maxRedirs == 0)
         {
             // Disable
             p.curl.set(CurlOption.followlocation, 0);


### PR DESCRIPTION
maxRedirects(uint maxRedirs) specify in its documentation string that uint.max can be used for infinite redirection.

But in the code, when a uint.max value is used, redirects are disabled, by setting CurlOption.followlocation to 0.

This PR switch off redirection if maxRedirs is equal to 0, and allow redirections up to maxRedirs otherwise.