### PR TITLE
Fix #10161: Add isValidUTF to validate strings without an exception.

### DIFF
--- a/std/utf.d
+++ b/std/utf.d
@@ -42,6 +42,7 @@ $(TR $(TD Index) $(TD
 $(TR $(TD Validation) $(TD
     $(LREF isValidDchar)
     $(LREF isValidCodepoint)
+    $(LREF isValidUTF)
     $(LREF validate)
 ))
 $(TR $(TD Miscellaneous) $(TD
@@ -2926,10 +2927,168 @@ if (isSomeChar!C)
 /* =================== Validation ======================= */
 
 /++
+    Returns whether the given string is well-formed Unicode or not.
+
+    See_Also:
+        $(LREF validate)
+  +/
+bool isValidUTF(S)(S str) @safe pure nothrow @nogc
+if (isSomeString!S)
+{
+    static if (is(immutable ElementEncodingType!S == immutable dchar))
+    {
+        foreach (c; str)
+        {
+            if (!isValidDchar(c))
+                return false;
+        }
+
+        return true;
+    }
+    else
+    {
+        static if (is(immutable ElementEncodingType!S == immutable char))
+            enum replacementDcharString = "\uFFFD";
+        else static if (is(immutable ElementEncodingType!S == immutable wchar))
+            enum replacementDcharString = "\uFFFD"w;
+        else
+            static assert(false, "The template constraint or static if is wrong.");
+
+        size_t i = 0;
+        while (i < str.length)
+        {
+            // The extra work here is because while decode will replace invalid
+            // Unicode with the replacement character, the replacement character
+            // is valid Unicode. So, it's possible that the string already has
+            // the replacement character in it (presumably due to invalid
+            // Unicode having been replaced by some other code previously), and
+            // we don't want to flag that as being invalid Unicode.
+            immutable before = i;
+            if (str.decode!(UseReplacementDchar.yes)(i) == replacementDchar)
+            {
+                auto temp = str[before .. $];
+                if (temp.length >= replacementDcharString.length &&
+                    temp[0 .. replacementDcharString.length] == replacementDcharString)
+                {
+                    continue;
+                }
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+///
+@safe unittest
+{
+    char[] a = [167, 133, 175];
+    assert(!isValidUTF(a));
+
+    assert(isValidUTF("hello world"));
+    assert(isValidUTF("ドラング・ロックス"));
+}
+
+@safe unittest
+{
+    // UTF-8
+    assert("😁".isValidUTF());
+    assert("hello\u07FF\uD7FF\U00010000\U0010FFFF".isValidUTF());
+    assert("\U0010fff8 𐁊 foo 𐂓".isValidUTF());
+    assert("𐁄𐂌𐃯 hello ディラン".isValidUTF());
+    assert("noe\u0308l".isValidUTF());
+    assert("ドラング・ロックス".isValidUTF());
+
+    {
+        char[] str = [72, 101, 108, 108, 111, 32, 0, 185, 203, 219, 251, 255];
+        assert(!str.isValidUTF());
+    }
+    {
+        char[] str = [65, 29, 225, 18, 50, 62, 194, 29];
+        assert(!str.isValidUTF());
+    }
+
+    assert("\uFFFD".isValidUTF());
+    assert("\uFFFD\uFFFD".isValidUTF());
+    assert("\uFFFD\uFFFD\uFFFD".isValidUTF());
+    assert("\uFFFDa\uFFFDb\uFFFDc".isValidUTF());
+    assert("0\uFFFD0".isValidUTF());
+    assert("ドラング\uFFFD・\uFFFDロックス".isValidUTF());
+
+    assert(!("\uFFFD" ~ [char(226), char(203)]).isValidUTF());
+    assert(!([char(194)] ~ "\uFFFD").isValidUTF());
+
+    // UTF-16
+    assert("😁"w.isValidUTF());
+    assert("hello\u07FF\uD7FF\U00010000\U0010FFFF"w.isValidUTF());
+    assert("\U0010fff8 𐁊 foo 𐂓"w.isValidUTF());
+    assert("𐁄𐂌𐃯 hello ディラン"w.isValidUTF());
+    assert("noe\u0308l"w.isValidUTF());
+    assert("ドラング・ロックス"w.isValidUTF());
+
+    {
+        wchar[] str = [12390, 101, 108, 19, 111, 10929, 0, 185, 0xD800, 219, 251, 255];
+        assert(!str.isValidUTF());
+    }
+    {
+        wchar[] str = [65, 29, 225, 18, 0xD907, 62, 194, 29];
+        assert(!str.isValidUTF());
+    }
+
+    assert("\uFFFD"w.isValidUTF());
+    assert("\uFFFD\uFFFD"w.isValidUTF());
+    assert("\uFFFD\uFFFD\uFFFD"w.isValidUTF());
+    assert("\uFFFDa\uFFFDb\uFFFDc"w.isValidUTF());
+    assert("0\uFFFD0"w.isValidUTF());
+    assert("ドラング\uFFFD・\uFFFDロックス"w.isValidUTF());
+
+    assert(!("\uFFFD"w ~ [wchar(0xD999), wchar(27)]).isValidUTF());
+    assert(!([wchar(0xDABA)] ~ "\uFFFD"w).isValidUTF());
+
+    // UTF-32
+    assert("😁"d.isValidUTF());
+    assert("hello\u07FF\uD7FF\U00010000\U0010FFFF"d.isValidUTF());
+    assert("\U0010fff8 𐁊 foo 𐂓"d.isValidUTF());
+    assert("𐁄𐂌𐃯 hello ディラン"d.isValidUTF());
+    assert("noe\u0308l"d.isValidUTF());
+    assert("ドラング・ロックス"d.isValidUTF());
+
+    {
+        dchar[] str = [72, 101, 108, 108, 111, 32, 0, 185, 0xDDDD, 219, 251, 255];
+        assert(!str.isValidUTF());
+    }
+    {
+        dchar[] str = [65, 29, 225, 18, 50, 62, cast(dchar) 0x111111, 29];
+        assert(!str.isValidUTF());
+    }
+
+    assert("\uFFFD"d.isValidUTF());
+    assert("\uFFFD\uFFFD"d.isValidUTF());
+    assert("\uFFFD\uFFFD\uFFFD"d.isValidUTF());
+    assert("\uFFFDa\uFFFDb\uFFFDc"d.isValidUTF());
+    assert("0\uFFFD0"d.isValidUTF());
+    assert("ドラング\uFFFD・\uFFFDロックス"d.isValidUTF());
+
+    assert(!("\uFFFD"d ~ [cast(dchar) 0x222222, dchar(203)]).isValidUTF());
+    assert(!([dchar(0xDFDF)] ~ "\uFFFD"d).isValidUTF());
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=12923
+@safe unittest
+{
+    char[] a = [167, 133, 175];
+    assert(!isValidUTF(a));
+}
+
+/++
     Checks to see if `str` is well-formed unicode or not.
 
     Throws:
         `UTFException` if `str` is not well-formed.
+
+    See_Also:
+        $(LREF isValidUTF)
   +/
 void validate(S)(in S str) @safe pure
 if (isSomeString!S)


### PR DESCRIPTION
std.utf.validate validates whether a string is valid Unicode and throws if it isn't. There are cases where that's desirable, but if the code wants to simply ask the question of whether a string is valid UTF-8/UTF-16/UTF-32, what you really want is a function that returns true or false and not a function which throws an exception. The exception makes sense when you want users of your code to handle it, but it doesn't make sense when simply asking the question, since it's awkward to use in such a situation and adds unnecessary overhead.

decode currently has two ways that it handles incorrect Unicode. It either throws a UTFException if the decoding fails, because the encoding is invalid (and that's what validate uses), or it converts the invalid Unicode to the Unicode replacement character, which is valid Unicode but represents that there was previously bad data in the string.

Ideally, we would add a third mode which returned whether the next code point was valid, but implementing that requires quite a lot of refactoring, and my previous attempt at doing so 10+ years ago got rejected by Andrei on the grounds that it was too ugly. And neither I nor anyone else has taken the time since to make another attempt (or if they have, they haven't created a PR for it, or the PR was rejected, and I never saw it). So, the best that we have is unfortunately still the validate function.

Using decode and checking for the replacement character is not a sufficient solution for validating the string, because it may have already had the replacement character in it, and in that case, it would be valid Unicode in spite of the fact that decode returned the replacement character. So, we really need a better solution. I've been putting this off for way too long on the basis that what we really need is to refactor decode, and taking the time to do that is not high on my list of priorities, but I've now come up with an alternate solution which is almost as good but which is much simpler.

What I've now come up with as a fix is to use decode on the string and check for the replacement character, but instead of treating the replacement character as invalid, we then check for whether the string contained the replacement character at that index. If it did contain it, then decode returned it because it was already there, and that part of the string is valid, whereas if it didn't contain it, then that part of the string is invalid Unicode, and thus the string is invalid UTF-8/UTF-16/UTF-32.

I fully expect that this is not quite as efficient as the "correct" solution of reworking decode for the third case, but it should be close, and it's _much_ more efficient than using validate to throw a UTFException that you catch. Also, if we decide to rework decode later for this third use case, the new function which this adds - isValidUTF - can simply be reworked to use that new version of decode without breaking any code.

This does involve adding a new symbol to Phobos, so it technically requires Atila's approval. Andrei did previously approve the symbol but rejected the refactoring I did in order to implement it. So, I would expect it to be approved, but it's obviously not my call.