### PR TITLE
Some fixes for phobos.sys.traits due to recent dmd changes

### DIFF
--- a/phobos/sys/traits.d
+++ b/phobos/sys/traits.d
@@ -2725,7 +2725,7 @@ template isSameSymbol(alias lhs)
     static assert(!isSameSymbol!(double, const double));
     static assert(!isSameSymbol!(double, int));
     static assert( isSameSymbol!(Object, Object));
-    static assert( isSameSymbol!(Object, const Object));
+    static assert(!isSameSymbol!(Object, const Object));
 
     static assert(!isSameSymbol!(i, int));
     static assert( isSameSymbol!(typeof(i), int));

--- a/phobos/sys/traits.d
+++ b/phobos/sys/traits.d
@@ -5448,7 +5448,7 @@ template hasComplexCopying(T)
   +/
 template hasComplexDestruction(T)
 {
-    alias hasComplexDestruction = __traits(needsDestruction, T);
+    enum hasComplexDestruction = __traits(needsDestruction, T);
 }
 
 ///

--- a/phobos/sys/traits.d
+++ b/phobos/sys/traits.d
@@ -5725,13 +5725,13 @@ else
     alias testWithQualifiers = assertWithQualifiers!hasIndirections;
 
     foreach (T; AliasSeq!(bool, byte, ubyte, short, ushort, int, uint, long, ulong,
-                          float, double, real, char, wchar, dchar, int function(string), void))
+                          float, double, real, char, wchar, dchar, int function(string)))
     {
         mixin testWithQualifiers!(T, false);
         mixin testWithQualifiers!(T*, true);
         mixin testWithQualifiers!(T[], true);
 
-        mixin testWithQualifiers!(T[42], is(T == void));
+        mixin testWithQualifiers!(T[42], false);
         mixin testWithQualifiers!(T[0], false);
 
         mixin testWithQualifiers!(T*[42], true);
@@ -5741,7 +5741,7 @@ else
         mixin testWithQualifiers!(T[][0], false);
     }
 
-    foreach (T; AliasSeq!(int[int], int delegate(string)))
+    foreach (T; AliasSeq!(int[int], int delegate(string), void))
     {
         mixin testWithQualifiers!(T, true);
         mixin testWithQualifiers!(T*, true);


### PR DESCRIPTION
Each of the individual commit messages has more info, but this fixes a bug per commit message. Two of the three involve fixes to dmd which in turn broke the tests in phobos.sys.traits which were based on the old behavior. So, those two commit fix the tests to match the new (correct) behavior. The third involves `alias` having been used in `hasComplexDestruction` when `enum` should have been used. I guess that a recent compiler change made that mistake an error, which is fine, since it is wrong, but this then fixes the mistake so that the code compiles again.