### PR TITLE
std.regex: note that repetitions inside lookaround can be polynomial

### DIFF
--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -234,6 +234,15 @@ They met on 24/01/1970.
      )
   )
 
+  $(P $(B Note on performance:) each time a lookahead or lookbehind
+  assertion is reached, its subexpression is matched from scratch by a
+  separate matcher, with no result reused between evaluations. As a result,
+  an assertion whose subexpression contains an unbounded repetition
+  (*, +, {n,}) can make matching take time polynomial in the length of the
+  input, which is most likely to matter for long or untrusted input. Where
+  the pattern allows, avoid repetitions inside lookaround, otherwise
+  consider bounding the input length.)
+
   $(REG_START Character classes )
   $(REG_TABLE
     $(REG_TITLE Pattern element, Semantics )


### PR DESCRIPTION
Each time a lookahead or lookbehind assertion is reached, its subexpression is matched from scratch by a separate matcher, with no result reused between evaluations. An assertion whose subexpression contains an unbounded repetition can therefore be re-scanned at many positions, making matching polynomial in the input length, which is most likely to bite on long or untrusted input. Document this in the pattern syntax section, pointing at avoiding repetitions inside lookaround where the pattern allows or bounding the input length otherwise.