### PR TITLE
std.regex: build the loop prefilter when a loop is followed by an OrChar

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -1158,7 +1158,10 @@ void optimize(Char)(ref Regex!Char zis)
                 case Char:
                     set.add(ir[i].data, ir[i].data+1);
                     goto default;
-                //TODO: OrChar
+                case OrChar://assumes IRL!(OrChar) == 1
+                    foreach (k; 0 .. ir[i].sequence)
+                        set.add(ir[i+k].data, ir[i+k].data+1);
+                    goto default;
                 case Trie, CodepointSet:
                     set = zis.charsets[ir[i].data];
                     goto default;

--- a/std/regex/package.d
+++ b/std/regex/package.d
@@ -466,6 +466,17 @@ if (isSomeString!(S))
     assert(indexOf(regexString, 'U') >= 0, "String representation should include flags.");
 }
 
+@system unittest
+{
+    // A loop followed by a small char-alternation (an OrChar, e.g. produced by
+    // case-insensitive matching) should get the same InfiniteBloom prefilter
+    // that a loop followed by a single character does.
+    assert(regex("a*b").filters.length > 0,
+        "loop followed by a single char should build a bloom prefilter");
+    assert(regex("(?i)a*b").filters.length > 0,
+        "loop followed by an OrChar should build a bloom prefilter too");
+}
+
 public auto regexImpl(S)(const S pattern, const(char)[] flags="")
 if (isSomeString!(typeof(pattern)))
 {


### PR DESCRIPTION
The optimizer builds an InfiniteBloom prefilter from the set of characters that can follow an unbounded loop, so the engines can prune the loop-exit branch when the current character cannot start what comes after the loop. The follow-set helper handled Char, CodepointSet and Trie but skipped OrChar -- a run of single-codepoint alternatives produced, for example, by case-insensitive matching. A loop followed by such an alternation (e.g. case-insensitive a*b) therefore never got the prefilter, unlike a loop followed by a single character.

This was an oversight rather than a deliberate exclusion: the leading Shift-Or prefilter already folds OrChar runs into its bit mask, so only the loop-exit prefilter was missing the case.

Handle OrChar in the follow-set computation by adding every alternative in the run. The change is purely additive: the previously unhandled case returned an empty set and the prefilter was simply not built, so match results are unchanged; the prefilter now also covers OrChar followers, which lets the engines skip the loop-exit branch on more inputs.