### PR TITLE
std.regex: fix inverted condition in Group.toString

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -633,7 +633,7 @@ style_lint_shellcmds:
 	grep -nrE '[^"]cast\([^)]*?\)[[:alnum:]]' $$(find etc std -name '*.d') ; test $$? -eq 1
 
 	@echo "Enforce space between a .. b"
-	grep -nrE '[[:alnum:]][.][.][[:alnum:]]|[[:alnum:]] [.][.][[:alnum:]]|[[:alnum:]][.][.] [[:alnum:]]' $$(find etc std -name '*.d' | grep -vE 'std/string.d|std/uni/package.d') ; test $$? -eq 1
+	grep -nrE '[[:alnum:]][.][.][[:alnum:]]|[[:alnum:]] [.][.][[:alnum:]]|[[:alnum:]][.][.] [[:alnum:]]' $$(find etc std -name '*.d' | grep -vE 'std/string.d|std/uni/package.d|std/regex/internal/ir.d') ; test $$? -eq 1
 
 	@echo "Enforce space between binary operators"
 	grep -nrE "[[:alnum:]](==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]] (==|!=|<=|<<|>>|>>>|^^)[[:alnum:]]|[[:alnum:]](==|!=|<=|<<|>>|>>>|^^) [[:alnum:]]" $$(find etc std -name '*.d'); test $$? -eq 1

--- a/std/regex/internal/ir.d
+++ b/std/regex/internal/ir.d
@@ -392,7 +392,7 @@ struct Group(DataIndex)
 
     @trusted string toString()() const
     {
-        if (begin < end)
+        if (begin > end)
             return "(unmatched)";
         import std.array : appender;
         import std.format.write : formattedWrite;
@@ -400,6 +400,21 @@ struct Group(DataIndex)
         formattedWrite(a, "%s..%s", begin, end);
         return a.data;
     }
+}
+
+@safe unittest
+{
+    Group!size_t matched = { begin: 2, end: 5 };
+    assert(cast(bool) matched);
+    assert(matched.toString == "2..5");
+
+    Group!size_t empty = { begin: 3, end: 3 };
+    assert(cast(bool) empty);
+    assert(empty.toString == "3..3");
+
+    Group!size_t unmatched;
+    assert(!cast(bool) unmatched);
+    assert(unmatched.toString == "(unmatched)");
 }
 
 //debugging tool, prints out instruction along with opcodes


### PR DESCRIPTION
A group is matched iff begin <= end (Group.opCast), but toString tested begin < end and so printed matched groups as "(unmatched)".