### PR TITLE
Fix #11035: std.regex: multi-digit backreference silently drops the overshooting digit

### DIFF
--- a/std/regex/internal/parser.d
+++ b/std/regex/internal/parser.d
@@ -968,17 +968,13 @@ if (isForwardRange!R && is(ElementType!R : dchar))
         case '1': .. case '9':
             uint nref = cast(uint) front - '0';
             immutable maxBackref = sum(g.groupStack.data);
-            enforce(nref < maxBackref, "Backref to unseen group");
-            //perl's disambiguation rule i.e.
-            //get next digit only if there is such group number
             popFront();
-            while (nref < maxBackref && !empty && std.ascii.isDigit(front))
+            while (!empty && std.ascii.isDigit(front))
             {
                 nref = nref * 10 + front - '0';
                 popFront();
             }
-            if (nref >= maxBackref)
-                nref /= 10;
+            enforce(nref < maxBackref, "Backref to unseen group");
             enforce(!g.isOpenGroup(nref), "Backref to open group");
             uint localLimit = maxBackref - g.groupStack.top;
             if (nref >= localLimit)

--- a/std/regex/internal/tests2.d
+++ b/std/regex/internal/tests2.d
@@ -711,3 +711,12 @@ version (none) // TODO: revist once we have proper benchmark framework
     ma = ma2;
     assert(ma[1] == "");
 }
+
+// https://github.com/dlang/phobos/issues/11035
+@safe unittest
+{
+    assertThrown(regex(`(a)\12`));
+    assertThrown(regex(`(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)\123`));
+    // a valid multi-digit backref still works
+    assertNotThrown(regex(`(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)\12`));
+}


### PR DESCRIPTION
\12 with no group 12 was parsed as \1, discarding the trailing digit.
Read the full number and error like the single-digit case.

I believe this is not a breaking change, perl's disambiguation rule for that never worked before.

### Feature request or issue tracking

Closes #11035

## Pre-review checklist

- [x] I have performed a self-review of my code.
- [x] If my PR fixes a bug or introduces a new feature, I have added thorough tests.
- ~~[ ] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.~~