### PR TITLE
Socket: adds closeOnDestruction flag to ctor arguments

### DIFF
--- a/std/socket.d
+++ b/std/socket.d
@@ -29,6 +29,7 @@ import core.stdc.stdint, core.stdc.stdlib, core.stdc.string, std.conv, std.strin
 import core.stdc.config;
 import core.time : dur, Duration;
 import std.exception;
+import std.typecons: Flag;
 
 import std.internal.cstring;
 
@@ -2661,6 +2662,7 @@ class Socket
 private:
     socket_t sock;
     AddressFamily _family;
+    const bool closeOnDestruction = true;
 
     version (Windows)
         bool _blocking = true;         /// Property to get or set whether the socket is blocking or nonblocking.
@@ -2772,10 +2774,20 @@ public:
         this._family = af;
     }
 
+    /// Use an existing socket handle.
+    ///
+    ///Params:
+    ///    closeOnDestruction = If No doesn't close underlying system socket in the destructor.
+    this(socket_t sock, AddressFamily af, Flag!"closeOnDestruction" closeOnDestruction) pure nothrow @nogc
+    {
+        this.closeOnDestruction = closeOnDestruction;
+        this(sock, af);
+    }
 
     ~this() nothrow @nogc
     {
-        close();
+        if (closeOnDestruction)
+            close();
     }
 
 


### PR DESCRIPTION
<!-- Hi,
     Thank you for your contribution!
     Please assist reviewers by filling out this template. -->
## Rationale

There is a case that is not covered by the `std.socket.Socket`:
When we get a ready-made socket_t from somewhere (from a 3rd-party library, for example), using it idiomatically in the D style, and after it we should just leave the socket "as is", because all other handling of this socket_t is performed by 3rd-party code.

Currently, if we want to do it this way, we have to duplicate the socket:
https://github.com/denizzzka/dpq2/blob/master/src/dpq2/connection.d#L227
and then `Socket` will close duplicate in desctructor without side-effects.

## Solution

`closeOnDestruction` flag added into ctor arguments, it allows not close underlying system socket in the destructor of `Socket`

## Pre-review checklist

- [x] I have performed a self-review of my code.
- [ ] If my PR fixes a bug or introduces a new feature, I have added thorough tests.

I think this case doesn't need testing.

- [ ] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.
