### PR TITLE
std.regex: drop redundant bmatch run from the test suite

### DIFF
--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -465,7 +465,6 @@ debug(std_regex_test) import std.stdio;
     }
 
     ct_tests();
-    run_tests!bmatch(); //backtracker
-    run_tests!match(); //thompson VM
+    run_tests!match();
 }
 

--- a/std/regex/internal/tests.d
+++ b/std/regex/internal/tests.d
@@ -464,7 +464,17 @@ debug(std_regex_test) import std.stdio;
         debug(std_regex_test) writeln("!!! FReD C-T test done !!!");
     }
 
+    // Force the backtracking engine to exercise it on every pattern.
+    auto bmatchForced(R, RegEx)(R input, RegEx re)
+    {
+        import std.regex.internal.ir : RuntimeFactory, BasicElementOf;
+        import std.regex.internal.backtracking : BacktrackingMatcher;
+        alias Char = BasicElementOf!R;
+        return match(input, re.withFactory(new RuntimeFactory!(BacktrackingMatcher, Char)));
+    }
+
     ct_tests();
-    run_tests!match();
+    run_tests!match(); // engine auto-selected per pattern
+    run_tests!bmatchForced(); // force the backtracking engine on every pattern
 }
 


### PR DESCRIPTION
## Rationale

match and bmatch are equivalent (both pick the engine from the pattern), so running run_tests!match() only.

## Pre-review checklist

- [x] I have performed a self-review of my code.
- ~~[ ] If my PR fixes a bug or introduces a new feature, I have added thorough tests.~~
- ~~[ ] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.~~