### PR TITLE
Fix #11047: Sufficiently big BigUint multiplications fail during CTFE

### DIFF
--- a/std/internal/math/biguintcore.d
+++ b/std/internal/math/biguintcore.d
@@ -197,8 +197,16 @@ else alias multibyteSquare = std.internal.math.biguintnoasm.multibyteSquare;
 // Half the size of the data cache.
 @nogc nothrow pure @safe size_t getCacheLimit()
 {
-    import core.cpuid : dataCaches;
-    return dataCaches[0].size * 1024 / 2;
+    if (__ctfe)
+    {
+        // Chosen arbitrarily.
+        return 8192;
+    }
+    else
+    {
+        import core.cpuid : dataCaches;
+        return dataCaches[0].size * 1024 / 2;
+    }
 }
 enum size_t FASTDIVLIMIT = 100; // crossover to recursive division
 
@@ -1265,6 +1273,12 @@ public:
     BigUint a = [3];
     int b = 5;
     assert(BigUint.mulInt(a,b) == 15);
+}
+
+// https://github.com/dlang/phobos/issues/11047
+@safe pure nothrow unittest
+{
+    enum ctfeLargeMultiplication = BigUint.mul(BigUint(ulong(1)) << ulong(33), BigUint(ulong(1)) << ulong(32));
 }
 
 // Remove leading zeros from x, to restore the BigUint invariant


### PR DESCRIPTION
<!-- Hi,
     Thank you for your contribution!
     Please assist reviewers by filling out this template. -->
## Rationale

<!-- Additional comments go here. -->


### Feature request or issue tracking

<!-- Please update the issue number (e.g. `#10974`) below, if applicable.
     Otherwise, feel free to remove this section. -->

Closes #11047.


## Pre-review checklist

- [x] I have performed a self-review of my code.
- [x] If my PR fixes a bug or introduces a new feature, I have added thorough tests.
- [x] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.

---

When both operands of a `std.internal.math.biguintcore.BigUint` multiplication exceed a certain threshold (the threshold appears to be `1 << 32`) during CTFE, the multiplication will fail as `std.internal.math.biguintcore.mulInternal` attempts to use `core.cpuid.dataCaches`, via `std.internal.math.biguintcore.getCacheLimit`, to optimise algorithm selection.

The proposed fix is simple: use an arbitrary value for `getCacheLimit`, during CTFE, in lieu of `core.cpuid.dataCaches`.

`getCacheLimit` is used in one place, and solely to optimise algorithm selection; no functional change is introduced by this PR.

