### PR TITLE
std.array.replaceInPlace: Use memmove when replacement increases length

### DIFF
--- a/std/array.d
+++ b/std/array.d
@@ -3114,11 +3114,24 @@ if (is(typeof(replace(array, from, to, stuff))))
         }
         else
         {
-            // replacement increases length
-            // @@@TODO@@@: optimize this
-            immutable replaceLen = to - from;
-            array[from .. to] = stuff[0 .. replaceLen];
-            insertInPlace(array, to, stuff[replaceLen .. $]);
+            immutable rangeLength = to - from;
+            immutable oldLength = array.length;
+            array.length = oldLength + stuff.length - rangeLength;
+
+            immutable tailLength = oldLength - (from + rangeLength);
+
+            T[] src = array[from + rangeLength .. oldLength];
+            T[] dst = array[from + stuff.length .. $];
+
+            pragma(inline, true) static void _memmove(T[] dst, T[] src, size_t size) @trusted
+            {
+              import core.stdc.string : memmove;
+              memmove(dst.ptr, src.ptr, size);
+            }
+
+            _memmove(dst, src, tailLength * T.sizeof);
+
+            array[from .. from + stuff.length] = stuff[];
         }
     }
     else


### PR DESCRIPTION
```sh
$ cat main.d
import std.stdio;
import std.datetime.stopwatch;
import std.datetime;
import std.array;

void main()
{
  auto res = benchmark!(test)(100_000_000);
  auto dur = res[0].total!"msecs";
  writeln(dur);
}

void test()
{
  int[] xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
  xs.replaceInPlace(5, 10, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
}
$ dmd -boundscheck=off -release main.d
$ ./main.exe
17990 (BEFORE)
$ dmd -boundscheck=off -release -I./projects/phobos -L./projects/phobos/phobos64.lib main.d
$ ./main.exe
15598 (AFTER)
```