### PR TITLE
Use closefrom on NetBSD

### DIFF
--- a/std/process.d
+++ b/std/process.d
@@ -1029,6 +1029,8 @@ private Pid spawnProcessPosix(scope const(char[])[] args,
             {
                 version (FreeBSD)
                     import core.sys.freebsd.unistd : closefrom;
+                version (NetBSD)
+                    import core.sys.netbsd.unistd : closefrom;
                 else version (OpenBSD)
                     import core.sys.openbsd.unistd : closefrom;
                 else version (Hurd)


### PR DESCRIPTION
When testing D in the GCC tree on NetBSD/amd64, every test using the shared libgphobos fails to run:

	libgphobos.so: undefined reference to `dirfd'

This patch uses the NetBSD version of closefrom from companion DMD PR#23382

	Provide closefrom on NetBSD
	https://github.com/dlang/dmd/pull/23382

to avoid this.

Tested on amd64-pc-netbsd10.1.

<!-- Hi,
     Thank you for your contribution!
     Please assist reviewers by filling out this template. -->
## Rationale

<!-- Additional comments go here. -->

With this patch and the corresponding DMD PR #23382, D test results inside the GCC tree are quite reasonable:
```
		=== gdc tests ===


Running target unix
FAIL: gdc.test/runnable/builtin.d   execution test
FAIL: gdc.test/runnable/builtin.d -shared-libphobos   execution test
UNRESOLVED: gdc.test/runnable/test20275.d   compilation failed to produce executable
UNRESOLVED: gdc.test/runnable/test20275.d -shared-libphobos   compilation failed to produce executable

		=== gdc Summary ===

# of expected passes		13498
# of unexpected failures	2
# of unresolved testcases	2
# of unsupported tests		609

		=== libphobos tests ===


Running target unix
FAIL: libphobos.druntime/shared/core/stdc/wctype.d execution test
FAIL: libphobos.druntime/shared/core/thread/osthread.d execution test
FAIL: libphobos.druntime/static/core/stdc/wctype.d execution test
FAIL: libphobos.druntime/static/core/thread/osthread.d execution test
FAIL: libphobos.phobos/std_complex.d execution test
FAIL: libphobos.phobos/std_experimental_allocator_building_blocks_aligned_block_list.d execution test
FAIL: libphobos.phobos/std_experimental_allocator_building_blocks_ascending_page_allocator.d execution test
FAIL: libphobos.phobos/std_file.d execution test

		=== libphobos Summary ===

# of expected passes		703
# of unexpected failures	8
```

### Feature request or issue tracking

<!-- Please update the issue number (e.g. `#10974`) below, if applicable.
     Otherwise, feel free to remove this section. -->

Closes #10974.


## Pre-review checklist

- [ x] I have performed a self-review of my code.
- [ ] If my PR fixes a bug or introduces a new feature, I have added thorough tests.
- [ ] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.
