### PR TITLE
Fix #11017: drop unsupported bitwise ops from Saturate docs

### DIFF
--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -2517,9 +2517,11 @@ struct Saturate
 static:
     /**
 
-    Implements saturation for operators `+=`, `-=`, `*=`, `/=`, `%=`, `^^=`, `&=`, `|=`, `^=`, `<<=`, `>>=`,
+    Implements saturation for operators `+=`, `-=`, `*=`, `/=`, `%=`, `^^=`, `<<=`, `>>=`,
     and `>>>=`. This hook is called if the result of the binary operation does
     not fit in `Lhs` without loss of information or a change in sign.
+    Bitwise operators (`&`, `|`, `^`, and the corresponding op-assign forms) are
+    not supported.
 
     Params:
     Rhs = The right-hand side type in the assignment, after the operation has
@@ -2551,7 +2553,8 @@ static:
     /**
 
     Implements saturation for operators `+`, `-` (unary and binary), `*`, `/`,
-    `%`, `^^`, `&`, `|`, `^`, `<<`, `>>`, and `>>>`.
+    `%`, `^^`, `<<`, `>>`, and `>>>`. Bitwise operators (`&`, `|`, and `^`) are
+    not supported.
 
     For unary `-`, `onOverflow` is called if $(D lhs == Lhs.min) and `Lhs` is a
     signed type. The function returns `Lhs.max`.
@@ -2607,6 +2610,17 @@ static:
         assert(checked!Saturate(100) << 33 == int.max);
         assert(checked!Saturate(100) >> -1 == int.max);
         assert(checked!Saturate(100) >> 33 == 0);
+    }
+    /// Bitwise operators are not supported with `Saturate`.
+    @safe unittest
+    {
+        auto x = checked!Saturate(10);
+        static assert(!__traits(compiles, x & 10));
+        static assert(!__traits(compiles, x | 10));
+        static assert(!__traits(compiles, x ^ 10));
+        static assert(!__traits(compiles, x &= 10));
+        static assert(!__traits(compiles, x |= 10));
+        static assert(!__traits(compiles, x ^= 10));
     }
 }
 

--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -2594,7 +2594,7 @@ static:
         else static if (x == ">>" || x == ">>>")
             return rhs >= 0 ? 0 : Lhs.max;
         else static if (x == "&" || x == "|" || x == "^")
-            return mixin("lhs" ~ x ~ "rhs");
+            assert(false);
         else
             static assert(false);
     }

--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -2517,7 +2517,7 @@ struct Saturate
 static:
     /**
 
-    Implements saturation for operators `+=`, `-=`, `*=`, `/=`, `%=`, `^^=`, `<<=`, `>>=`,
+    Implements saturation for operators `+=`, `-=`, `*=`, `/=`, `%=`, `^^=`, `&=`, `|=`, `^=`, `<<=`, `>>=`,
     and `>>>=`. This hook is called if the result of the binary operation does
     not fit in `Lhs` without loss of information or a change in sign.
 
@@ -2551,7 +2551,7 @@ static:
     /**
 
     Implements saturation for operators `+`, `-` (unary and binary), `*`, `/`,
-    `%`, `^^`, `<<`, `>>`, and `>>>`.
+    `%`, `^^`, `&`, `|`, `^`, `<<`, `>>`, and `>>>`.
 
     For unary `-`, `onOverflow` is called if $(D lhs == Lhs.min) and `Lhs` is a
     signed type. The function returns `Lhs.max`.
@@ -2593,6 +2593,8 @@ static:
             return rhs >= 0 ? Lhs.max : 0;
         else static if (x == ">>" || x == ">>>")
             return rhs >= 0 ? 0 : Lhs.max;
+        else static if (x == "&" || x == "|" || x == "^")
+            return mixin("lhs" ~ x ~ "rhs");
         else
             static assert(false);
     }
@@ -2608,16 +2610,20 @@ static:
         assert(checked!Saturate(100) >> -1 == int.max);
         assert(checked!Saturate(100) >> 33 == 0);
     }
-    // https://github.com/dlang/phobos/issues/11017
+    ///
     @safe unittest
     {
-        auto x = checked!Saturate(10);
-        static assert(!__traits(compiles, x & 10));
-        static assert(!__traits(compiles, x | 10));
-        static assert(!__traits(compiles, x ^ 10));
-        static assert(!__traits(compiles, x &= 10));
-        static assert(!__traits(compiles, x |= 10));
-        static assert(!__traits(compiles, x ^= 10));
+        assert((checked!Saturate(0b1100) & 0b1010) == 0b1000);
+        assert((checked!Saturate(0b1100) | 0b1010) == 0b1110);
+        assert((checked!Saturate(0b1100) ^ 0b1010) == 0b0110);
+
+        auto x = checked!Saturate(0b1100);
+        x &= 0b1010;
+        assert(x == 0b1000);
+        x |= 0b0011;
+        assert(x == 0b1011);
+        x ^= 0b1111;
+        assert(x == 0b0100);
     }
 }
 

--- a/std/checkedint.d
+++ b/std/checkedint.d
@@ -2520,8 +2520,6 @@ static:
     Implements saturation for operators `+=`, `-=`, `*=`, `/=`, `%=`, `^^=`, `<<=`, `>>=`,
     and `>>>=`. This hook is called if the result of the binary operation does
     not fit in `Lhs` without loss of information or a change in sign.
-    Bitwise operators (`&`, `|`, `^`, and the corresponding op-assign forms) are
-    not supported.
 
     Params:
     Rhs = The right-hand side type in the assignment, after the operation has
@@ -2553,8 +2551,7 @@ static:
     /**
 
     Implements saturation for operators `+`, `-` (unary and binary), `*`, `/`,
-    `%`, `^^`, `<<`, `>>`, and `>>>`. Bitwise operators (`&`, `|`, and `^`) are
-    not supported.
+    `%`, `^^`, `<<`, `>>`, and `>>>`.
 
     For unary `-`, `onOverflow` is called if $(D lhs == Lhs.min) and `Lhs` is a
     signed type. The function returns `Lhs.max`.
@@ -2611,7 +2608,7 @@ static:
         assert(checked!Saturate(100) >> -1 == int.max);
         assert(checked!Saturate(100) >> 33 == 0);
     }
-    /// Bitwise operators are not supported with `Saturate`.
+    // https://github.com/dlang/phobos/issues/11017
     @safe unittest
     {
         auto x = checked!Saturate(10);


### PR DESCRIPTION
## Rationale

`Saturate`'s documentation listed bitwise operators (`&`, `|`, `^`, and the corresponding op-assign forms) among the supported operators, but using them hits `static assert(false)` in `onOverflow`.

This removes those operators from the documented lists so the docs only describe what `Saturate` actually implements. Added tests so that mismatch can't quietly come back.

### Feature request or issue tracking

Closes #11017.


## Pre-review checklist

- [x] I have performed a self-review of my code.
- [x] If my PR fixes a bug or introduces a new feature, I have added thorough tests.
- [x] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.


### LLM/AI disclosure

This PR was written with the assistance of an LLM/AI.
