### PR TITLE
Fix Issue 11067 - allow string handlers in std.sumtype.match

### DIFF
--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1697,6 +1697,10 @@ enum bool isSumType(T) = is(T : SumType!Args, Args...);
  * a function with more than one overload is given as a handler, all of the
  * overloads are considered as potential matches.
  *
+ * String handlers such as `"a.member"` are accepted via
+ * $(REF unaryFun, std,functional) (and $(REF binaryFun, std,functional) for
+ * multiple dispatch), consistent with the rest of Phobos.
+ *
  * Templated handlers are also accepted, and will match any type for which they
  * can be [implicitly instantiated](https://dlang.org/glossary.html#ifti).
  * (Remember that a $(DDSUBLINK spec/expression,function_literals, function literal)
@@ -1727,6 +1731,18 @@ template match(handlers...)
     {
         return matchImpl!(Yes.exhaustive, handlers)(args);
     }
+}
+
+// https://github.com/dlang/phobos/issues/11067
+version (D_BetterC) {} else
+@safe unittest
+{
+    struct Foo { int value; }
+    struct Bar { int value; }
+
+    alias Sum = SumType!(Foo, Bar);
+
+    assert(Sum(Bar(3)).match!"a.value" == 3);
 }
 
 /** $(DIVID avoiding-unintentional-matches, $(H3 Avoiding unintentional matches))
@@ -1956,6 +1972,18 @@ private template Iota(size_t n)
     assert(Iota!3 == AliasSeq!(0, 1, 2));
 }
 
+private template handlerAlias(alias handler, size_t nArgs)
+{
+    import std.functional : binaryFun, unaryFun;
+
+    static if (nArgs == 1)
+        alias handlerAlias = unaryFun!handler;
+    else static if (nArgs == 2)
+        alias handlerAlias = binaryFun!handler;
+    else
+        alias handlerAlias = handler;
+}
+
 private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 {
     auto ref matchImpl(SumTypes...)(auto ref SumTypes args)
@@ -2033,7 +2061,8 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
             {
                 static foreach (hid, handler; handlers)
                 {
-                    static if (canMatch!(handler, valueTypes!caseId))
+                    static if (canMatch!(handlerAlias!(handler, valueTypes!caseId.length),
+                            valueTypes!caseId))
                     {
                         if (result[caseId] == noMatch)
                         {
@@ -2066,7 +2095,8 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 
         static foreach (size_t hid, handler; handlers)
         {
-            mixin("alias ", handlerName!hid, " = handler;");
+            mixin("alias ", handlerName!hid, " = handlerAlias!(handler, ",
+                toCtString!(SumTypes.length), ");");
         }
 
         // Single dispatch (fast path)

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1698,7 +1698,11 @@ enum bool isSumType(T) = is(T : SumType!Args, Args...);
  * overloads are considered as potential matches.
  *
  * String handlers such as `"a.member"` are accepted via
- * $(REF unaryFun, std,functional), consistent with the rest of Phobos.
+ * $(REF unaryFun, std,functional) when matching one [SumType], or
+ * $(REF binaryFun, std,functional) when matching two, consistent with the rest
+ * of Phobos. String handlers are not supported when matching three or more
+ * [SumType]s; use a function literal in that case. (This mirrors
+ * `std.functional`, which provides only unary and binary string adapters.)
  *
  * Templated handlers are also accepted, and will match any type for which they
  * can be [implicitly instantiated](https://dlang.org/glossary.html#ifti).
@@ -1742,6 +1746,13 @@ version (D_BetterC) {} else
     alias Sum = SumType!(Foo, Bar);
 
     assert(Sum(Bar(3)).match!"a.value" == 3);
+
+    // Two SumType arguments use binaryFun ("a", "b")
+    assert(match!"a.value + b.value"(Sum(Foo(2)), Sum(Bar(3))) == 5);
+
+    // String handlers are not supported for 3+ SumType arguments
+    alias S = SumType!int;
+    static assert(!__traits(compiles, match!"a + b + c"(S(1), S(2), S(3))));
 }
 
 /** $(DIVID avoiding-unintentional-matches, $(H3 Avoiding unintentional matches))
@@ -1971,13 +1982,39 @@ private template Iota(size_t n)
     assert(Iota!3 == AliasSeq!(0, 1, 2));
 }
 
+/* Adapt handlers with unaryFun/binaryFun when matching 1/2 SumTypes.
+ *
+ * `nArgs` is the number of SumType *arguments* passed to match (dispatch
+ * arity), not the number of mutually exclusive member types in a SumType.
+ * std.functional has no n-ary string adapter, so string handlers are rejected
+ * for 3+ arguments.
+ */
+private template handlerAlias(alias handler, size_t nArgs)
+{
+    import std.functional : binaryFun, unaryFun;
+
+    static if (nArgs == 1)
+        alias handlerAlias = unaryFun!handler;
+    else static if (nArgs == 2)
+        alias handlerAlias = binaryFun!handler;
+    else
+    {
+        static if (is(typeof(handler) : string))
+        {
+            static assert(0,
+                "String handlers are only supported when matching 1 or 2 " ~
+                "SumTypes; use a function literal for 3 or more.");
+        }
+        else
+            alias handlerAlias = handler;
+    }
+}
+
 private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 {
     auto ref matchImpl(SumTypes...)(auto ref SumTypes args)
     if (allSatisfy!(isSumType, SumTypes) && args.length > 0)
     {
-        import std.functional : unaryFun;
-
         // Single dispatch (fast path)
         static if (args.length == 1)
         {
@@ -2050,7 +2087,8 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
             {
                 static foreach (hid, handler; handlers)
                 {
-                    static if (canMatch!(unaryFun!handler, valueTypes!caseId))
+                    static if (canMatch!(handlerAlias!(handler, SumTypes.length),
+                            valueTypes!caseId))
                     {
                         if (result[caseId] == noMatch)
                         {
@@ -2083,7 +2121,8 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 
         static foreach (size_t hid, handler; handlers)
         {
-            mixin("alias ", handlerName!hid, " = unaryFun!handler;");
+            mixin("alias ", handlerName!hid, " = handlerAlias!(handler, ",
+                toCtString!(SumTypes.length), ");");
         }
 
         // Single dispatch (fast path)

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -2061,7 +2061,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
             {
                 static foreach (hid, handler; handlers)
                 {
-                    static if (canMatch!(handlerAlias!(handler, valueTypes!caseId.length),
+                    static if (canMatch!(handlerAlias!(handler, SumTypes.length),
                             valueTypes!caseId))
                     {
                         if (result[caseId] == noMatch)

--- a/std/sumtype.d
+++ b/std/sumtype.d
@@ -1698,8 +1698,7 @@ enum bool isSumType(T) = is(T : SumType!Args, Args...);
  * overloads are considered as potential matches.
  *
  * String handlers such as `"a.member"` are accepted via
- * $(REF unaryFun, std,functional) (and $(REF binaryFun, std,functional) for
- * multiple dispatch), consistent with the rest of Phobos.
+ * $(REF unaryFun, std,functional), consistent with the rest of Phobos.
  *
  * Templated handlers are also accepted, and will match any type for which they
  * can be [implicitly instantiated](https://dlang.org/glossary.html#ifti).
@@ -1972,23 +1971,13 @@ private template Iota(size_t n)
     assert(Iota!3 == AliasSeq!(0, 1, 2));
 }
 
-private template handlerAlias(alias handler, size_t nArgs)
-{
-    import std.functional : binaryFun, unaryFun;
-
-    static if (nArgs == 1)
-        alias handlerAlias = unaryFun!handler;
-    else static if (nArgs == 2)
-        alias handlerAlias = binaryFun!handler;
-    else
-        alias handlerAlias = handler;
-}
-
 private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 {
     auto ref matchImpl(SumTypes...)(auto ref SumTypes args)
     if (allSatisfy!(isSumType, SumTypes) && args.length > 0)
     {
+        import std.functional : unaryFun;
+
         // Single dispatch (fast path)
         static if (args.length == 1)
         {
@@ -2061,8 +2050,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
             {
                 static foreach (hid, handler; handlers)
                 {
-                    static if (canMatch!(handlerAlias!(handler, SumTypes.length),
-                            valueTypes!caseId))
+                    static if (canMatch!(unaryFun!handler, valueTypes!caseId))
                     {
                         if (result[caseId] == noMatch)
                         {
@@ -2095,8 +2083,7 @@ private template matchImpl(Flag!"exhaustive" exhaustive, handlers...)
 
         static foreach (size_t hid, handler; handlers)
         {
-            mixin("alias ", handlerName!hid, " = handlerAlias!(handler, ",
-                toCtString!(SumTypes.length), ");");
+            mixin("alias ", handlerName!hid, " = unaryFun!handler;");
         }
 
         // Single dispatch (fast path)


### PR DESCRIPTION
## Summary

Apply `std.functional.unaryFun` / `binaryFun` inside `matchImpl` when selecting and invoking handlers, so string forms like `value.match!a.member` work consistently with the rest of Phobos.

Fixes #11067

## Approach

Per review feedback: no separate string-handler adapter layer, and no pre-wrapping of all handlers at the `match`/`tryMatch` call site (that broke `-betterC` and misused `SumTypes.length` as handler arity). Instead, handlers are adapted only inside `matchImpl` via a small `handlerAlias` helper that delegates to `unaryFun` (1 arg) or `binaryFun` (2 args).

## Test plan

- [x] `version (D_BetterC)`-guarded unittest for `match!a.value`
- [x] CI