### PR TITLE
Fix Issue 11050 - correct FloatingPointControl invalidException docs

### DIFF
--- a/std/math/hardware.d
+++ b/std/math/hardware.d
@@ -470,7 +470,7 @@ version (FloatingPointControlSupport)
   by zero), $(I overflow), and $(I invalid operation) exceptions are enabled.
   These three are combined into a $(I severeExceptions) value for convenience.
   Note in particular that if $(I invalidException) is enabled, a hardware trap
-  will be generated whenever an uninitialized floating-point variable is used.
+  will be generated when an invalid operation occurs (as defined by IEEE 754).
 
   All changes are temporary. The previous state is restored at the
   end of the scope.
@@ -482,17 +482,14 @@ Example:
     FloatingPointControl fpctrl;
 
     // Enable hardware exceptions for division by zero, overflow to infinity,
-    // invalid operations, and uninitialized floating-point variables.
+    // and invalid operations.
     fpctrl.enableExceptions(FloatingPointControl.severeExceptions);
 
-    // This will generate a hardware exception, if x is a
-    // default-initialized floating point variable:
-    real x; // Add `= 0` or even `= real.nan` to not throw the exception.
-    real y = x * 3.0;
+    // This will generate a hardware exception when invalidException is enabled:
+    real y = 0.0 / 0.0;
 
-    // The exception is only thrown for default-uninitialized NaN-s.
-    // NaN-s with other payload are valid:
-    real z = y * real.nan; // ok
+    // NaN-producing operations that are not invalid do not trap:
+    real z = real.nan * 3.0; // ok
 
     // The set hardware exceptions and rounding modes will be disabled when
     // leaving this scope.


### PR DESCRIPTION
## Summary
- Remove incorrect doc claims that invalidException traps use of uninitialized floating-point variables
- Clarify that invalidException traps IEEE 754 invalid operations
- Update the FloatingPointControl example to use 0.0/0.0 instead of default-initialized storage

Fixes #11050

## Test plan
- [ ] Documentation-only change; no code behavior change
- [ ] CI
