### PR TITLE
WASI support

### DIFF
--- a/etc/c/curl.d
+++ b/etc/c/curl.d
@@ -35,6 +35,10 @@
 
 module etc.c.curl;
 
+// WASIp1's networking is extremely limited
+version (WASIp1) {}
+else:
+
 import core.stdc.config;
 import core.stdc.time;
 import std.socket;

--- a/std/concurrency.d
+++ b/std/concurrency.d
@@ -88,7 +88,8 @@ import std.range.interfaces : InputRange;
 import std.traits;
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     __gshared string received;
     static void spawnedFunc(Tid ownerTid)
@@ -413,7 +414,8 @@ public:
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=21512
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.format : format;
 
@@ -452,7 +454,8 @@ public:
     return thisInfo.owner;
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.exception : assertThrown;
 
@@ -526,6 +529,8 @@ if (isSpawnable!(F, T))
 }
 
 ///
+version (WASI) {} // WASI is single-threaded
+else
 @system unittest
 {
     static void f(string msg)
@@ -537,7 +542,8 @@ if (isSpawnable!(F, T))
 }
 
 /// Fails: char[] has mutable aliasing.
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     string msg = "Hello, World!";
 
@@ -551,7 +557,8 @@ if (isSpawnable!(F, T))
 }
 
 /// New thread with anonymous function
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     spawn({
         ownerTid.send("This is so great!");
@@ -559,7 +566,8 @@ if (isSpawnable!(F, T))
     assert(receiveOnly!string == "This is so great!");
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import core.thread : thread_joinAll;
 
@@ -630,7 +638,8 @@ if (isSpawnable!(F, T))
     return spawnTid;
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     void function() fn1;
     void function(int) fn2;
@@ -757,7 +766,8 @@ do
 }
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.variant : Variant;
 
@@ -895,7 +905,8 @@ do
 }
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     auto tid = spawn(
     {
@@ -905,7 +916,8 @@ do
 }
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     auto tid = spawn(
     {
@@ -915,7 +927,8 @@ do
 }
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     struct Record { string name; int age; }
 
@@ -930,7 +943,8 @@ do
     send(tid, 0.5, Record("Alice", 31));
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     static void t1(Tid mainTid)
     {
@@ -1244,7 +1258,8 @@ void join(Tid tid)
 }
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import core.time : msecs;
     import core.thread : Thread;
@@ -1478,7 +1493,8 @@ class ThreadScheduler : Scheduler
  * This is an example scheduler that creates a new `Fiber` per call to spawn
  * and multiplexes the execution of all fibers within the main thread.
  */
-class FiberScheduler : Scheduler
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else class FiberScheduler : Scheduler
 {
     /**
      * This creates a new `Fiber` for the supplied op and then starts the
@@ -1669,7 +1685,8 @@ private:
     size_t m_pos;
 }
 
-@system unittest
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else @system unittest
 {
     static void receive(Condition cond, ref size_t received)
     {
@@ -1729,16 +1746,23 @@ __gshared Scheduler scheduler;
  */
 void yield() nothrow
 {
-    auto fiber = Fiber.getThis();
-    if (!(cast(IsGenerator) fiber))
+    version (WebAssembly) // No Fiber support on Wasm yet
     {
-        if (scheduler is null)
+        scheduler.yield();
+    }
+    else
+    {
+        auto fiber = Fiber.getThis();
+        if (!(cast(IsGenerator) fiber))
         {
-            if (fiber)
-                return Fiber.yield();
+            if (scheduler is null)
+            {
+                if (fiber)
+                    return Fiber.yield();
+            }
+            else
+                scheduler.yield();
         }
-        else
-            scheduler.yield();
     }
 }
 
@@ -1751,7 +1775,8 @@ private interface IsGenerator {}
  * that periodically returns values of type `T` to the
  * caller via `yield`.  This is represented as an InputRange.
  */
-class Generator(T) :
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else class Generator(T) :
     Fiber, IsGenerator, InputRange!T
 {
     /**
@@ -1934,7 +1959,8 @@ private:
 }
 
 ///
-@system unittest
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else @system unittest
 {
     auto tid = spawn({
         int i;
@@ -1962,7 +1988,8 @@ private:
  * Params:
  *  value = The value to yield.
  */
-void yield(T)(ref T value)
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else void yield(T)(ref T value)
 {
     Generator!T cur = cast(Generator!T) Fiber.getThis();
     if (cur !is null && cur.state == Fiber.State.EXEC)
@@ -1974,12 +2001,14 @@ void yield(T)(ref T value)
 }
 
 /// ditto
-void yield(T)(T value)
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else void yield(T)(T value)
 {
     yield(value);
 }
 
-@system unittest
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else @system unittest
 {
     import core.exception;
     import std.exception;
@@ -2033,7 +2062,8 @@ void yield(T)(T value)
     scheduler = null;
 }
 ///
-@system unittest
+version (WebAssembly) {} // No Fiber support on Wasm yet
+else @system unittest
 {
     import std.range;
 
@@ -2670,7 +2700,8 @@ private
     }
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.typecons : tuple, Tuple;
 
@@ -2763,7 +2794,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init)
     assert(MySingleton.instance !is null);
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     static class MySingleton
     {
@@ -2832,7 +2864,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 }
 
 /// Use a separate mutex when init blocks on another thread that might also call initOnce.
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import core.sync.mutex : Mutex;
 
@@ -2864,7 +2897,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 }
 
 // test ability to send shared arrays
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     static shared int[] x = new shared(int)[1];
     auto tid = spawn({
@@ -2878,7 +2912,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=13930
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     immutable aa = ["0":0];
     thisTid.send(aa);
@@ -2886,7 +2921,8 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=19345
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     static struct Aggregate { const int a; const int[5] b; }
     static void t1(Tid mainTid)
@@ -2916,7 +2952,10 @@ auto ref initOnce(alias var)(lazy typeof(var) init, Mutex mutex)
     static assert(__traits(compiles, receiveOnly!noreturn()                 ));
     static assert(__traits(compiles, send(Tid.init, noreturn.init)          ));
     static assert(__traits(compiles, prioritySend(Tid.init, noreturn.init)  ));
-    static assert(__traits(compiles, yield(noreturn.init)                   ));
+
+    version (WebAssembly) {}
+    else
+        static assert(__traits(compiles, yield(noreturn.init)                   ));
 
     static assert(__traits(compiles, {
         __gshared noreturn n;

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -96,7 +96,7 @@ version (Windows)
 }
 else version (Posix)
 {
-    import core.sys.posix.signal : timespec;
+    import core.sys.posix.time : timespec;
     import core.sys.posix.sys.types : time_t;
 }
 
@@ -398,6 +398,32 @@ public:
                     import core.sys.hurd.time : CLOCK_REALTIME_COARSE;
                     import core.sys.posix.time : clock_gettime, CLOCK_REALTIME;
                     static if (clockType == ClockType.coarse)       alias clockArg = CLOCK_REALTIME_COARSE;
+                    else static if (clockType == ClockType.normal)  alias clockArg = CLOCK_REALTIME;
+                    else static if (clockType == ClockType.precise) alias clockArg = CLOCK_REALTIME;
+                    else static assert(0, "Previous static if is wrong.");
+                    timespec ts = void;
+                    immutable error = clock_gettime(clockArg, &ts);
+                    // Posix clock_gettime called with a valid address and valid clock_id is only
+                    // permitted to fail if the number of seconds does not fit in time_t. If tv_sec
+                    // is long or larger overflow won't happen before 292 billion years A.D.
+                    static if (ts.tv_sec.max < long.max)
+                    {
+                        if (error)
+                            throw new TimeException("Call to clock_gettime() failed");
+                    }
+                    return convert!("seconds", "hnsecs")(ts.tv_sec) +
+                           ts.tv_nsec / 100 +
+                           hnsecsToUnixEpoch;
+                }
+            }
+            else version (CRuntime_WASI)
+            {
+                static if (clockType == ClockType.second)
+                    return unixTimeToStdTime(core.stdc.time.time(null));
+                else
+                {
+                    import core.sys.posix.time : clock_gettime, CLOCK_REALTIME;
+                    static if (clockType == ClockType.coarse)       alias clockArg = CLOCK_REALTIME;
                     else static if (clockType == ClockType.normal)  alias clockArg = CLOCK_REALTIME;
                     else static if (clockType == ClockType.precise) alias clockArg = CLOCK_REALTIME;
                     else static assert(0, "Previous static if is wrong.");
@@ -2675,8 +2701,12 @@ public:
         {
             import std.utf : toUTFz;
             timeInfo.tm_gmtoff = cast(int) convert!("hnsecs", "seconds")(adjTime - _stdTime);
-            auto zone = timeInfo.tm_isdst ? _timezone.dstName : _timezone.stdName;
-            timeInfo.tm_zone = zone.toUTFz!(char*)();
+
+            version (CRuntime_WASI) {} // no tzname on WASI
+            else {
+                auto zone = timeInfo.tm_isdst ? _timezone.dstName : _timezone.stdName;
+                timeInfo.tm_zone = zone.toUTFz!(char*)();
+            }
         }
 
         return timeInfo;
@@ -2687,7 +2717,8 @@ public:
         import std.conv : to;
         import core.time;
 
-        version (Posix)
+        version (CRuntime_WASI) {}
+        else version (Posix)
         {
             import std.datetime.timezone : clearTZEnvVar, setTZEnvVar;
             setTZEnvVar("America/Los_Angeles");
@@ -2711,7 +2742,8 @@ public:
             else version (Windows)
                 assert(timeInfo.tm_isdst == 0 || timeInfo.tm_isdst == 1);
 
-            version (Posix)
+            version (CRuntime_WASI) {}
+            else version (Posix)
             {
                 assert(timeInfo.tm_gmtoff == -8 * 60 * 60);
                 assert(to!string(timeInfo.tm_zone) == "PST");
@@ -2730,12 +2762,15 @@ public:
             assert(timeInfo.tm_wday == 0);
             assert(timeInfo.tm_yday == 184);
 
-            version (Posix)
+            version (CRuntime_WASI)
+                assert(timeInfo.tm_isdst == 0 || timeInfo.tm_isdst == 1);
+            else version (Posix)
                 assert(timeInfo.tm_isdst == 1);
             else version (Windows)
                 assert(timeInfo.tm_isdst == 0 || timeInfo.tm_isdst == 1);
 
-            version (Posix)
+            version (CRuntime_WASI) {}
+            else version (Posix)
             {
                 assert(timeInfo.tm_gmtoff == -7 * 60 * 60);
                 assert(to!string(timeInfo.tm_zone) == "PDT");
@@ -2758,7 +2793,8 @@ public:
             assert(timeInfo.tm_yday == 0);
             assert(timeInfo.tm_isdst == 0);
 
-            version (Posix)
+            version (CRuntime_WASI) {}
+            else version (Posix)
             {
                 assert(timeInfo.tm_gmtoff == 0);
                 assert(to!string(timeInfo.tm_zone) == "SysTime.init's timezone");

--- a/std/datetime/systime.d
+++ b/std/datetime/systime.d
@@ -2703,7 +2703,8 @@ public:
             timeInfo.tm_gmtoff = cast(int) convert!("hnsecs", "seconds")(adjTime - _stdTime);
 
             version (CRuntime_WASI) {} // no tzname on WASI
-            else {
+            else
+            {
                 auto zone = timeInfo.tm_isdst ? _timezone.dstName : _timezone.stdName;
                 timeInfo.tm_zone = zone.toUTFz!(char*)();
             }

--- a/std/datetime/timezone.d
+++ b/std/datetime/timezone.d
@@ -57,7 +57,7 @@ version (Windows)
 }
 else version (Posix)
 {
-    import core.sys.posix.signal : timespec;
+    import core.sys.posix.time : timespec;
     import core.sys.posix.sys.types : time_t;
 }
 
@@ -196,7 +196,8 @@ public:
     // Since reading in the time zone files could be expensive, most unit tests
     // are consolidated into this one unittest block which minimizes how often
     // it reads a time zone file.
-    @system unittest
+    version (WASI) {}
+    else @system unittest
     {
         import core.exception : AssertError;
         import std.conv : to;
@@ -254,7 +255,8 @@ public:
             assert(cast(DateTime) dst == dstDate);
             assert(std == stdUTC);
 
-            version (Posix)
+            version (CRuntime_WASI) {}
+            else version (Posix)
             {
                 setTZEnvVar(tzName);
 
@@ -583,7 +585,11 @@ public:
       +/
     @property override string stdName() @trusted const scope nothrow
     {
-        version (Posix)
+        version (CRuntime_WASI)
+        {
+            assert(0, "No tzname on WASI");
+        }
+        else version (Posix)
         {
             import core.stdc.time : tzname;
             import std.conv : to;
@@ -636,6 +642,10 @@ public:
         {
             // The same bug on NetBSD 7+
         }
+        else version (CRuntime_WASI)
+        {
+            // WASI has no tzname and no ability to configure the timezone.
+        }
         else
         {
             assert(LocalTime().stdName !is null);
@@ -668,7 +678,11 @@ public:
       +/
     @property override string dstName() @trusted const scope nothrow
     {
-        version (Posix)
+        version (CRuntime_WASI)
+        {
+            assert(0, "No tzname on WASI");
+        }
+        else version (Posix)
         {
             import core.stdc.time : tzname;
             import std.conv : to;
@@ -710,7 +724,8 @@ public:
         }
     }
 
-    @safe unittest
+    version (CRuntime_WASI) {}
+    else @safe unittest
     {
         // tzname, called from dstName, isn't set by default for Musl.
         version (CRuntime_Musl)
@@ -785,7 +800,8 @@ public:
     {
         LocalTime().hasDST;
 
-        version (Posix)
+        version (CRuntime_WASI) {}
+        else version (Posix)
         {
             scope(exit) clearTZEnvVar();
 
@@ -954,7 +970,8 @@ public:
         assert(LocalTime().tzToUTC(LocalTime().utcToTZ(0)) == 0);
         assert(LocalTime().utcToTZ(LocalTime().tzToUTC(0)) == 0);
 
-        version (Posix)
+        version (CRuntime_WASI) {}
+        else version (Posix)
         {
             scope(exit) clearTZEnvVar();
 
@@ -1101,11 +1118,17 @@ private:
     // operation the first time that LocalTime() is called.
     static immutable(LocalTime) singleton() @trusted
     {
-        import core.stdc.time : tzset;
         import std.concurrency : initOnce;
         static instance = new immutable(LocalTime)();
         static shared bool guard;
-        initOnce!guard({tzset(); return true;}());
+
+        version (CRuntime_WASI) {}
+        else
+        {
+            import core.stdc.time : tzset;
+            initOnce!guard({tzset(); return true;}());
+        }
+
         return instance;
     }
 
@@ -1185,7 +1208,8 @@ public:
     {
         assert(UTC().utcToTZ(0) == 0);
 
-        version (Posix)
+        version (CRuntime_WASI) {}
+        else version (Posix)
         {
             scope(exit) clearTZEnvVar();
 
@@ -1218,7 +1242,8 @@ public:
     {
         assert(UTC().tzToUTC(0) == 0);
 
-        version (Posix)
+        version (CRuntime_WASI) {}
+        else version (Posix)
         {
             scope(exit) clearTZEnvVar();
 
@@ -2032,6 +2057,10 @@ public:
     else version (Solaris)
     {
         enum defaultTZDatabaseDir = "/usr/share/lib/zoneinfo/";
+    }
+    else version (WASI)
+    {
+        enum defaultTZDatabaseDir = "";
     }
     else version (Posix)
     {
@@ -3435,6 +3464,7 @@ version (StdDdoc)
       +/
     void clearTZEnvVar() @safe nothrow;
 }
+else version (CRuntime_WASI) {}
 else version (Posix)
 {
     void setTZEnvVar(string tzDatabaseName) @trusted nothrow

--- a/std/exception.d
+++ b/std/exception.d
@@ -631,7 +631,8 @@ private noreturn bailOut(E : Throwable = Exception)(string file, size_t line, sc
 alias errnoEnforce = enforce!ErrnoException;
 
 ///
-@system unittest
+version (WASI) {} // thisExePath is not available on WASI
+else @system unittest
 {
     import core.stdc.stdio : fclose, fgets, fopen;
     import std.file : thisExePath;

--- a/std/experimental/allocator/building_blocks/aligned_block_list.d
+++ b/std/experimental/allocator/building_blocks/aligned_block_list.d
@@ -361,7 +361,8 @@ struct AlignedBlockList(Allocator, ParentAllocator, ulong theAlignment = (1 << 2
 }
 
 ///
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.experimental.allocator.building_blocks.segregator : Segregator;
@@ -520,7 +521,8 @@ shared struct SharedAlignedBlockList(Allocator, ParentAllocator, ulong theAlignm
 }
 
 ///
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.region : SharedBorrowedRegion;
     import std.experimental.allocator.building_blocks.ascending_page_allocator : SharedAscendingPageAllocator;
@@ -576,7 +578,8 @@ version (StdUnittest)
     }
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.region;
     import std.experimental.allocator.building_blocks.ascending_page_allocator;
@@ -636,7 +639,8 @@ version (StdUnittest)
     }
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.experimental.allocator.building_blocks.segregator : Segregator;

--- a/std/experimental/allocator/building_blocks/allocator_list.d
+++ b/std/experimental/allocator/building_blocks/allocator_list.d
@@ -622,7 +622,8 @@ template AllocatorList(alias factoryFunction,
 }
 
 ///
-version (Posix) @system unittest
+version (WebAssembly) {}
+else version (Posix) @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.free_list : ContiguousFreeList;
@@ -1072,7 +1073,8 @@ template SharedAllocatorList(alias factoryFunction,
     testAlloc(a2);
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -1130,7 +1132,8 @@ template SharedAllocatorList(alias factoryFunction,
     assert(a.deallocateAll());
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator :
         AscendingPageAllocator, SharedAscendingPageAllocator;
@@ -1202,7 +1205,8 @@ template SharedAllocatorList(alias factoryFunction,
     SharedAllocatorList!((n) => SharedAscendingPageAllocator(max(n, numPages * pageSize)), NullAllocator) a2;
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -1238,7 +1242,8 @@ template SharedAllocatorList(alias factoryFunction,
     assert(a.deallocateAll());
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.algorithm.comparison : max;
@@ -1259,7 +1264,8 @@ template SharedAllocatorList(alias factoryFunction,
     assert(a.deallocateAll());
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.ascending_page_allocator : AscendingPageAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
@@ -1294,7 +1300,8 @@ template SharedAllocatorList(alias factoryFunction,
     assert(a.deallocateAll());
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.experimental.allocator.building_blocks.region : SharedRegion;
     import core.thread : ThreadGroup;

--- a/std/experimental/allocator/building_blocks/ascending_page_allocator.d
+++ b/std/experimental/allocator/building_blocks/ascending_page_allocator.d
@@ -4,6 +4,9 @@ Source: $(PHOBOSSRC std/experimental/allocator/building_blocks/ascending_page_al
 */
 module std.experimental.allocator.building_blocks.ascending_page_allocator;
 
+version (WebAssembly) {}
+else:
+
 import core.memory : pageSize;
 
 import std.experimental.allocator.common;

--- a/std/experimental/allocator/building_blocks/bitmapped_block.d
+++ b/std/experimental/allocator/building_blocks/bitmapped_block.d
@@ -1661,7 +1661,8 @@ shared struct SharedBitmappedBlock(size_t theBlockSize, uint theAlignment = plat
 }
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
     import std.experimental.allocator.common : platformAlignment;

--- a/std/experimental/allocator/building_blocks/free_list.d
+++ b/std/experimental/allocator/building_blocks/free_list.d
@@ -1178,7 +1178,8 @@ struct SharedFreeList(ParentAllocator,
     assert(a.approxMaxLength  == 1);
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import core.thread : ThreadGroup;
     import std.algorithm.comparison : equal;

--- a/std/experimental/allocator/building_blocks/kernighan_ritchie.d
+++ b/std/experimental/allocator/building_blocks/kernighan_ritchie.d
@@ -673,7 +673,8 @@ It should perform slightly better because instead of searching through one
 large free list, it searches through several shorter lists in LRU order. Also,
 it actually returns memory to the operating system when possible.
 */
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list
@@ -714,7 +715,8 @@ it actually returns memory to the operating system when possible.
     }
 }
 
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.algorithm.comparison : max;
     import std.experimental.allocator.building_blocks.allocator_list

--- a/std/experimental/allocator/building_blocks/region.d
+++ b/std/experimental/allocator/building_blocks/region.d
@@ -898,6 +898,11 @@ version (CRuntime_Musl)
     // https://git.musl-libc.org/cgit/musl/commit/?id=7a995fe706e519a4f55399776ef0df9596101f93
     // https://git.musl-libc.org/cgit/musl/commit/?id=863d628d93ea341b6a32661a1654320ce69f6a07
 }
+version (CRuntime_WASI)
+{
+    // sbrk is very limited (only PAGE_SIZE increments, and only able to grow)
+    // brk has not been implemented
+}
 version (DragonFlyBSD)
 {
     // sbrk is deprecated in favor of mmap   (we could implement a mmap + MAP_NORESERVE + PROT_NONE version)
@@ -924,6 +929,7 @@ SbrkRegion) adversely.
 
 */
 version (CRuntime_Musl) {} else
+version (CRuntime_WASI) {} else
 version (DragonFlyBSD) {} else
 version (Posix) struct SbrkRegion(uint minAlign = platformAlignment)
 {
@@ -1107,6 +1113,7 @@ version (Posix) struct SbrkRegion(uint minAlign = platformAlignment)
 }
 
 version (CRuntime_Musl) {} else
+version (CRuntime_WASI) {} else
 version (DragonFlyBSD) {} else
 version (Posix) @system nothrow @nogc unittest
 {
@@ -1121,6 +1128,7 @@ version (Posix) @system nothrow @nogc unittest
 }
 
 version (CRuntime_Musl) {} else
+version (CRuntime_WASI) {} else
 version (DragonFlyBSD) {} else
 version (Posix) @system nothrow @nogc unittest
 {
@@ -1322,7 +1330,8 @@ shared struct SharedRegion(ParentAllocator,
     }
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 
@@ -1387,7 +1396,8 @@ shared struct SharedRegion(ParentAllocator,
     testAlloc(a2, false);
 }
 
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import std.experimental.allocator.mallocator : Mallocator;
 

--- a/std/experimental/allocator/common.d
+++ b/std/experimental/allocator/common.d
@@ -23,11 +23,17 @@ unittest
     import std.experimental.allocator.building_blocks.null_allocator : NullAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
     import std.experimental.allocator.gc_allocator : GCAllocator;
-    import std.experimental.allocator.mmap_allocator : MmapAllocator;
+
+    version (WebAssembly) {}
+    else import std.experimental.allocator.mmap_allocator : MmapAllocator;
+
     static assert(isAllocator!NullAllocator);
     static assert(isAllocator!Mallocator);
     static assert(isAllocator!GCAllocator);
-    static assert(isAllocator!MmapAllocator);
+
+    version (WebAssembly) {}
+    else static assert(isAllocator!MmapAllocator);
+
     static assert(!isAllocator!int);
 }
 
@@ -88,13 +94,18 @@ unittest
     import std.experimental.allocator.building_blocks.null_allocator : NullAllocator;
     import std.experimental.allocator.mallocator : Mallocator;
     import std.experimental.allocator.gc_allocator : GCAllocator;
-    import std.experimental.allocator.mmap_allocator : MmapAllocator;
+
+    version (WebAssembly) {}
+    else import std.experimental.allocator.mmap_allocator : MmapAllocator;
+
     struct S
     {
         mixin AllocatorState!NullAllocator n;
         mixin AllocatorState!GCAllocator g;
         mixin AllocatorState!Mallocator m;
-        mixin AllocatorState!MmapAllocator p;
+
+        version (WebAssembly) {}
+        else mixin AllocatorState!MmapAllocator p;
     }
     static assert(S.sizeof == 1);
 }

--- a/std/experimental/allocator/mmap_allocator.d
+++ b/std/experimental/allocator/mmap_allocator.d
@@ -4,6 +4,9 @@ Source: $(PHOBOSSRC std/experimental/allocator/_mmap_allocator.d)
 */
 module std.experimental.allocator.mmap_allocator;
 
+version (WebAssembly) {}
+else:
+
 /**
 Allocator (currently defined only for Posix and Windows) using
 $(D $(LINK2 https://en.wikipedia.org/wiki/Mmap, mmap))

--- a/std/experimental/allocator/showcase.d
+++ b/std/experimental/allocator/showcase.d
@@ -8,6 +8,9 @@ Source: $(PHOBOSSRC std/experimental/allocator/_showcase.d)
 */
 module std.experimental.allocator.showcase;
 
+version (WebAssembly) {}
+else:
+
 import std.experimental.allocator.building_blocks.fallback_allocator,
     std.experimental.allocator.gc_allocator,
     std.experimental.allocator.building_blocks.region;

--- a/std/experimental/allocator/typed.d
+++ b/std/experimental/allocator/typed.d
@@ -394,7 +394,8 @@ struct TypedAllocator(PrimaryAllocator, Policies...)
 }
 
 ///
-@system unittest
+version (WebAssembly) {}
+else @system unittest
 {
     import std.experimental.allocator.gc_allocator : GCAllocator;
     import std.experimental.allocator.mallocator : Mallocator;

--- a/std/file.d
+++ b/std/file.d
@@ -1834,6 +1834,14 @@ if (isSomeFiniteCharInputRange!R)
 
     source.write(".");
     assert(target.timeLastModified(SysTime.min) < source.timeLastModified);
+    version (CRuntime_WASI)
+    {
+        // WASI works at nanosecond precision, so make sure there's at least
+        // some nsec between our changes so there's a measurable difference.
+        import core.thread : Thread;
+        import core.time : dur;
+        Thread.sleep(5.dur!"nsecs");
+    }
     target.write(".");
     assert(target.timeLastModified(SysTime.min) >= source.timeLastModified);
 }
@@ -2204,7 +2212,16 @@ if (isConvertibleToString!R)
         scope(exit) source.remove, target.remove;
 
         target.write("target");
-        target.symlink(source);
+
+        // Wasmtime does not permit absolute symlinks; Use relative instead
+        version (CRuntime_WASI)
+        {
+            import std.path : baseName;
+            target.baseName.symlink(source);
+        }
+        else
+            target.symlink(source);
+
         assert(source.readText == "target");
         assert(source.isSymlink);
         assert(source.getLinkAttributes.attrIsSymlink);
@@ -2309,7 +2326,8 @@ if (isConvertibleToString!R)
 }
 
 /// setAttributes with a file
-@safe unittest
+version (CRuntime_WASI) {} // wasi-libc does not support chmod
+else @safe unittest
 {
     import std.exception : assertThrown;
     import std.conv : octal;
@@ -2335,7 +2353,8 @@ if (isConvertibleToString!R)
 }
 
 /// setAttributes with a directory
-@safe unittest
+version (CRuntime_WASI) {} // wasi-libc does not support chmod
+else @safe unittest
 {
     import std.exception : assertThrown;
     import std.conv : octal;
@@ -2763,7 +2782,16 @@ if (isConvertibleToString!R)
         scope(exit) source.remove, target.remove;
 
         target.write("target");
-        target.symlink(source);
+
+        // Wasmtime does not permit absolute symlinks; Use relative instead
+        version (CRuntime_WASI)
+        {
+            import std.path : baseName;
+            target.baseName.symlink(source);
+        }
+        else
+            target.symlink(source);
+
         assert(source.readText == "target");
         assert(source.isSymlink);
         assert(source.getLinkAttributes.attrIsSymlink);
@@ -2889,7 +2917,16 @@ bool attrIsSymlink(uint attributes) @safe pure nothrow @nogc
         scope(exit) source.remove, target.remove;
 
         target.write("target");
-        target.symlink(source);
+
+        // Wasmtime does not permit absolute symlinks; Use relative instead
+        version (CRuntime_WASI)
+        {
+            import std.path : baseName;
+            target.baseName.symlink(source);
+        }
+        else
+            target.symlink(source);
+
         assert(source.readText == "target");
         assert(source.isSymlink);
         assert(source.getLinkAttributes.attrIsSymlink);
@@ -3641,12 +3678,19 @@ else version (Posix) string getcwd() @trusted
     {
         return readLink("/proc/self/exe");
     }
+    else version (WASI)
+    {
+        import std.exception;
+        enforce(0, "thisExePath is not available on WASI");
+        return "";
+    }
     else
         static assert(0, "thisExePath is not supported on this platform");
 }
 
 ///
-@safe unittest
+version (WASI) {}
+else @safe unittest
 {
     import std.path : isAbsolute;
     auto path = thisExePath();
@@ -4452,7 +4496,8 @@ private void copyImpl(scope const(char)[] f, scope const(char)[] t,
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=11434
-@safe version (Posix) @safe unittest
+version (CRuntime_WASI) {} // wasi-libc has no chmod
+else version (Posix) @safe unittest
 {
     import std.conv : octal;
     auto t1 = deleteme, t2 = deleteme~"2";
@@ -4581,8 +4626,17 @@ version (Posix) @system unittest
     auto d = deleteme~"/a/b/c/d/e/f/g";
     enforce(collectException(mkdir(d)));
     mkdirRecurse(d);
-    core.sys.posix.unistd.symlink((deleteme~"/a/b/c\0").ptr,
-            (deleteme~"/link\0").ptr);
+
+    // Wasmtime does not permit absolute symlinks; Use relative instead
+    version (CRuntime_WASI)
+    {
+        core.sys.posix.unistd.symlink(("a/b/c\0").ptr,
+                (deleteme~"/link\0").ptr);
+    }
+    else
+        core.sys.posix.unistd.symlink((deleteme~"/a/b/c\0").ptr,
+                (deleteme~"/link\0").ptr);
+
     rmdirRecurse(deleteme~"/link");
     enforce(exists(d));
     rmdirRecurse(deleteme);
@@ -4591,7 +4645,13 @@ version (Posix) @system unittest
     d = deleteme~"/a/b/c/d/e/f/g";
     mkdirRecurse(d);
     const linkTarget = deleteme ~ "/link";
-    symlink(deleteme ~ "/a/b/c", linkTarget);
+
+    // Wasmtime does not permit absolute symlinks; Use relative instead
+    version (CRuntime_WASI)
+        symlink("a/b/c", linkTarget);
+    else
+        symlink(deleteme ~ "a/b/c", linkTarget);
+
     rmdirRecurse(deleteme);
     enforce(!exists(deleteme));
 }
@@ -4811,8 +4871,17 @@ private struct DirIteratorImpl
             for (dirent* fdata; (fdata = readdir(_stack[$-1].h)) != null; )
             {
                 // Skip "." and ".."
-                if (core.stdc.string.strcmp(&fdata.d_name[0], ".") &&
-                    core.stdc.string.strcmp(&fdata.d_name[0], ".."))
+                version (CRuntime_WASI)
+                {
+                    bool cond = core.stdc.string.strcmp(cast(char*)&fdata.d_name, ".") &&
+                        core.stdc.string.strcmp(cast(char*)&fdata.d_name, "..");
+                }
+                else
+                {
+                    bool cond = core.stdc.string.strcmp(&fdata.d_name[0], ".") &&
+                        core.stdc.string.strcmp(&fdata.d_name[0], "..");
+                }
+                if (cond)
                 {
                     _cur = DirEntry(_stack[$-1].dirpath, fdata);
                     return true;
@@ -5220,8 +5289,18 @@ auto dirEntries(bool useDIP1000 = dip1000Enabled)
     write(fpath, "hello world");
     version (Posix) () @trusted
     {
-        core.sys.posix.unistd.symlink((dpath ~ '\0').ptr, (sdpath ~ '\0').ptr);
-        core.sys.posix.unistd.symlink((fpath ~ '\0').ptr, (sfpath ~ '\0').ptr);
+        // Wasmtime does not permit absolute symlinks; Use relative instead
+        version (CRuntime_WASI)
+        {
+            import std.path : baseName;
+            core.sys.posix.unistd.symlink((dpath.baseName ~ '\0').ptr, (sdpath ~ '\0').ptr);
+            core.sys.posix.unistd.symlink((fpath.baseName ~ '\0').ptr, (sfpath ~ '\0').ptr);
+        }
+        else
+        {
+            core.sys.posix.unistd.symlink((dpath ~ '\0').ptr, (sdpath ~ '\0').ptr);
+            core.sys.posix.unistd.symlink((fpath ~ '\0').ptr, (sfpath ~ '\0').ptr);
+        }
     } ();
 
     static struct Flags { bool dir, file, link; }
@@ -5581,7 +5660,8 @@ ulong getAvailableDiskSpace(scope const(char)[] path) @safe
 }
 
 ///
-@safe unittest
+version (CRuntime_WASI) {}
+else @safe unittest
 {
     import std.exception : assertThrown;
 

--- a/std/file.d
+++ b/std/file.d
@@ -2326,14 +2326,14 @@ if (isConvertibleToString!R)
 }
 
 /// setAttributes with a file
-version (CRuntime_WASI) {} // wasi-libc does not support chmod
-else @safe unittest
+@safe unittest
 {
     import std.exception : assertThrown;
     import std.conv : octal;
 
     auto f = deleteme ~ "file";
-    version (Posix)
+    version (CRuntime_WASI) {} // wasi-libc does not support chmod
+    else version (Posix)
     {
         scope(exit) f.remove;
 
@@ -2353,14 +2353,14 @@ else @safe unittest
 }
 
 /// setAttributes with a directory
-version (CRuntime_WASI) {} // wasi-libc does not support chmod
-else @safe unittest
+@safe unittest
 {
     import std.exception : assertThrown;
     import std.conv : octal;
 
     auto dir = deleteme ~ "dir";
-    version (Posix)
+    version (CRuntime_WASI) {} // wasi-libc does not support chmod
+    else version (Posix)
     {
         scope(exit) dir.rmdir;
 
@@ -3680,7 +3680,7 @@ else version (Posix) string getcwd() @trusted
     }
     else version (WASI)
     {
-        import std.exception;
+        import std.exception : enforce;
         enforce(0, "thisExePath is not available on WASI");
         return "";
     }
@@ -3689,15 +3689,18 @@ else version (Posix) string getcwd() @trusted
 }
 
 ///
-version (WASI) {}
-else @safe unittest
+@safe unittest
 {
-    import std.path : isAbsolute;
-    auto path = thisExePath();
+    version (WASI) {}
+    else
+    {
+        import std.path : isAbsolute;
+        auto path = thisExePath();
 
-    assert(path.exists);
-    assert(path.isAbsolute);
-    assert(path.isFile);
+        assert(path.exists);
+        assert(path.isAbsolute);
+        assert(path.isFile);
+    }
 }
 
 version (StdDdoc)
@@ -5660,13 +5663,16 @@ ulong getAvailableDiskSpace(scope const(char)[] path) @safe
 }
 
 ///
-version (CRuntime_WASI) {}
-else @safe unittest
+@safe unittest
 {
-    import std.exception : assertThrown;
+    version (CRuntime_WASI) {}
+    else
+    {
+        import std.exception : assertThrown;
 
-    auto space = getAvailableDiskSpace(".");
-    assert(space > 0);
+        auto space = getAvailableDiskSpace(".");
+        assert(space > 0);
 
-    assertThrown!FileException(getAvailableDiskSpace("ThisFileDoesNotExist123123"));
+        assertThrown!FileException(getAvailableDiskSpace("ThisFileDoesNotExist123123"));
+    }
 }

--- a/std/internal/entropy.d
+++ b/std/internal/entropy.d
@@ -667,6 +667,10 @@ else version (OpenBSD) mixin entropyImpl!(
     SrcFunPair!(EntropySource.charDevURandom, getEntropyViaCharDevURandom),
     SrcFunPair!(EntropySource.charDevRandom, getEntropyViaCharDevRandom),
 );
+else version (CRuntime_WASI) mixin entropyImpl!(
+    EntropySource.arc4random,
+    SrcFunPair!(EntropySource.arc4random, getEntropyViaARC4Random)
+);
 else version (Posix) mixin entropyImpl!(
     EntropySource.charDevURandom,
     SrcFunPair!(EntropySource.charDevURandom, getEntropyViaCharDevURandom),
@@ -791,6 +795,8 @@ private
     version (NetBSD)
         version = SecureARC4Random;
     version (OpenBSD)
+        version = SecureARC4Random;
+    version (CRuntime_WASI)
         version = SecureARC4Random;
 
     version (SecureARC4Random)

--- a/std/logger/core.d
+++ b/std/logger/core.d
@@ -1542,7 +1542,8 @@ class StdForwardLogger : Logger
     auto nl1 = new StdForwardLogger(LogLevel.all);
 }
 
-@safe unittest
+version (WASI) {} // WASI is single-threaded
+else @safe unittest
 {
     import core.thread : Thread, msecs;
 
@@ -2870,7 +2871,8 @@ private void trustedStore(T)(ref shared T dst, ref T src) @trusted
 
 // check that thread-local logging does not propagate
 // to shared logger
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     import core.thread, std.concurrency;
 

--- a/std/mmfile.d
+++ b/std/mmfile.d
@@ -29,6 +29,9 @@
  */
 module std.mmfile;
 
+version (WebAssembly) {} // WebAssembly does not have memory mapping
+else:
+
 import core.stdc.errno;
 import core.stdc.stdio;
 import core.stdc.stdlib;

--- a/std/net/curl.d
+++ b/std/net/curl.d
@@ -157,6 +157,9 @@ Distributed under the Boost Software License, Version 1.0.
 */
 module std.net.curl;
 
+version (WASI) {}
+else:
+
 public import etc.c.curl : CurlOption;
 import core.time : dur;
 import etc.c.curl : CURLcode;

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -1059,6 +1059,13 @@ uint totalCPUsImpl() @nogc nothrow @trusted
         import core.sys.posix.unistd : _SC_NPROCESSORS_ONLN, sysconf;
         return cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
     }
+    else version (WASI)
+    {
+        // WASI is currently single-threaded, and has no way to discover
+        // how many processors the host has.
+
+        return 1;
+    }
     else
     {
         static assert(0, "Don't know how to get N CPUs on this OS.");
@@ -4236,7 +4243,11 @@ version (StdUnittest)
     import std.typecons : Tuple, tuple;
     import std.stdio;
 
-    poolInstance = new TaskPool(2);
+    version (WASI) // WASI is single-threaded
+        poolInstance = new TaskPool(0);
+    else
+        poolInstance = new TaskPool(2);
+
     scope(exit) poolInstance.stop();
 
     // The only way this can be verified is manually.
@@ -4282,10 +4293,14 @@ version (StdUnittest)
     assert(st2.args[0] == 1);
 
     // Test executeInNewThread().
-    auto ct = scopedTask!refFun(x);
-    ct.executeInNewThread(Thread.PRIORITY_MAX);
-    ct.yieldForce;
-    assert(ct.args[0] == 1);
+    version (WASI) {} // WASI is single-threaded
+    else
+    {
+        auto ct = scopedTask!refFun(x);
+        ct.executeInNewThread(Thread.PRIORITY_MAX);
+        ct.yieldForce;
+        assert(ct.args[0] == 1);
+    }
 
     // Test ref return.
     uint toInc = 0;
@@ -4417,7 +4432,13 @@ version (StdUnittest)
     auto parallelSum = poolInstance.reduce!"a + b"(wlRange);
     assert(parallelSum == 499500);
     assert(wlRange[0 .. 1][0] == wlRange[0]);
-    assert(wlRange[1 .. 2][0] == wlRange[1]);
+
+    version (WASI) {
+        // WASI is single-threaded
+        // TaskPool has only main thread; thus only one slot.
+    }
+    else
+        assert(wlRange[1 .. 2][0] == wlRange[1]);
 
     // Test finish()
     {

--- a/std/parallelism.d
+++ b/std/parallelism.d
@@ -4433,7 +4433,8 @@ version (StdUnittest)
     assert(parallelSum == 499500);
     assert(wlRange[0 .. 1][0] == wlRange[0]);
 
-    version (WASI) {
+    version (WASI)
+    {
         // WASI is single-threaded
         // TaskPool has only main thread; thus only one slot.
     }

--- a/std/path.d
+++ b/std/path.d
@@ -4059,6 +4059,10 @@ string expandTilde(return scope const string inputPath) @safe nothrow
             {
                 return path;
             }
+            else version (CRuntime_WASI) // neither does wasi-libc
+            {
+                return path;
+            }
             else
             {
                 import core.sys.posix.pwd : passwd, getpwnam_r;

--- a/std/process.d
+++ b/std/process.d
@@ -84,7 +84,7 @@ Macros:
 
 Note:
 Most of the functionality in this module is not available on iOS, tvOS
-and watchOS. The only functions available on those platforms are:
+, watchOS, and WASI. The only functions available on those platforms are:
 $(LREF environment), $(LREF thisProcessID) and $(LREF thisThreadID).
 */
 module std.process;
@@ -148,7 +148,8 @@ private
     {
         import core.sys.posix.unistd : getEnvironPtr = environ;
 
-        @system unittest
+        version (WASI) {} // WASI is single-threaded
+        else @system unittest
         {
             import core.thread : Thread;
             new Thread({assert(getEnvironPtr !is null);}).start();
@@ -636,8 +637,8 @@ private:
     }
 }
 
-
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     int pidA, pidB;
     ThreadID tidA, tidB;
@@ -667,6 +668,8 @@ package(std) string uniqueTempPath() @safe
         randomUUID().toString());
 }
 
+version (WASI) {}
+else:
 
 version (iOSDerived) {}
 else:

--- a/std/socket.d
+++ b/std/socket.d
@@ -1150,7 +1150,8 @@ Address[] getAddress(scope const(char)[] hostname, ushort port)
         Address[] addresses;
 
         version (CRuntime_WASI) {} // no DNS resolution in wasi-libc yet
-        else {
+        else
+        {
             addresses = getAddress("63.105.9.61");
             assert(addresses.length && addresses[0].toAddrString() == "63.105.9.61");
         }
@@ -1730,7 +1731,8 @@ public:
     });
 
     version (CRuntime_WASI) {} // No DNS resolution in wasi-libc yet
-    else {
+    else
+    {
         softUnittest({
             // test reverse lookup
             auto ih = new InternetHost;
@@ -2609,7 +2611,8 @@ public:
     }
 }
 
-version (CRuntime_WASI) {
+version (CRuntime_WASI)
+{
     // Some strange bug(?) where `select` read availability becomes sticky
     // after the first send, after even `recv`ing the data.
     //

--- a/std/socket.d
+++ b/std/socket.d
@@ -39,6 +39,10 @@ else version (TVOS)
 else version (WatchOS)
     version = iOSDerived;
 
+// WASIp1's networking is extremely limited
+version (WASIp1) {}
+else:
+
 @safe:
 
 version (Windows)
@@ -314,6 +318,7 @@ shared static this() @system
                                  GetProcAddress(ws2Lib, "freeaddrinfo");
         }
     }
+    else version (CRuntime_WASI) {} // getaddrinfo support is rather incomplete
     else version (Posix)
     {
         getnameinfoPointer = &getnameinfo;
@@ -334,46 +339,72 @@ shared static ~this() @system nothrow @nogc
 /**
  * The communication domain used to resolve an address.
  */
-enum AddressFamily: ushort
-{
-    UNSPEC =     AF_UNSPEC,     /// Unspecified address family
-    UNIX =       AF_UNIX,       /// Local communication (Unix socket)
-    INET =       AF_INET,       /// Internet Protocol version 4
-    IPX =        AF_IPX,        /// Novell IPX
-    APPLETALK =  AF_APPLETALK,  /// AppleTalk
-    INET6 =      AF_INET6,      /// Internet Protocol version 6
-}
+version (CRuntime_WASI)
+    enum AddressFamily: ushort
+    {
+        UNSPEC =     AF_UNSPEC,     /// Unspecified address family
+        UNIX =       AF_UNIX,       /// Local communication (Unix socket)
+        INET =       AF_INET,       /// Internet Protocol version 4
+        INET6 =      AF_INET6,      /// Internet Protocol version 6
+    }
+else
+    enum AddressFamily: ushort
+    {
+        UNSPEC =     AF_UNSPEC,     /// Unspecified address family
+        UNIX =       AF_UNIX,       /// Local communication (Unix socket)
+        INET =       AF_INET,       /// Internet Protocol version 4
+        IPX =        AF_IPX,        /// Novell IPX
+        APPLETALK =  AF_APPLETALK,  /// AppleTalk
+        INET6 =      AF_INET6,      /// Internet Protocol version 6
+    }
 
 
 /**
  * Communication semantics
  */
-enum SocketType: int
-{
-    STREAM =     SOCK_STREAM,           /// Sequenced, reliable, two-way communication-based byte streams
-    DGRAM =      SOCK_DGRAM,            /// Connectionless, unreliable datagrams with a fixed maximum length; data may be lost or arrive out of order
-    RAW =        SOCK_RAW,              /// Raw protocol access
-    RDM =        SOCK_RDM,              /// Reliably-delivered message datagrams
-    SEQPACKET =  SOCK_SEQPACKET,        /// Sequenced, reliable, two-way connection-based datagrams with a fixed maximum length
-}
+version (CRuntime_WASI)
+    enum SocketType: int
+    {
+        STREAM =     SOCK_STREAM,           /// Sequenced, reliable, two-way communication-based byte streams
+        DGRAM =      SOCK_DGRAM,            /// Connectionless, unreliable datagrams with a fixed maximum length; data may be lost or arrive out of order
+    }
+else
+    enum SocketType: int
+    {
+        STREAM =     SOCK_STREAM,           /// Sequenced, reliable, two-way communication-based byte streams
+        DGRAM =      SOCK_DGRAM,            /// Connectionless, unreliable datagrams with a fixed maximum length; data may be lost or arrive out of order
+        RAW =        SOCK_RAW,              /// Raw protocol access
+        RDM =        SOCK_RDM,              /// Reliably-delivered message datagrams
+        SEQPACKET =  SOCK_SEQPACKET,        /// Sequenced, reliable, two-way connection-based datagrams with a fixed maximum length
+    }
 
 
 /**
  * Protocol
  */
-enum ProtocolType: int
-{
-    IP =    IPPROTO_IP,         /// Internet Protocol version 4
-    ICMP =  IPPROTO_ICMP,       /// Internet Control Message Protocol
-    IGMP =  IPPROTO_IGMP,       /// Internet Group Management Protocol
-    GGP =   IPPROTO_GGP,        /// Gateway to Gateway Protocol
-    TCP =   IPPROTO_TCP,        /// Transmission Control Protocol
-    PUP =   IPPROTO_PUP,        /// PARC Universal Packet Protocol
-    UDP =   IPPROTO_UDP,        /// User Datagram Protocol
-    IDP =   IPPROTO_IDP,        /// Xerox NS protocol
-    RAW =   IPPROTO_RAW,        /// Raw IP packets
-    IPV6 =  IPPROTO_IPV6,       /// Internet Protocol version 6
-}
+version (CRuntime_WASI)
+    enum ProtocolType: int
+    {
+        IP =    IPPROTO_IP,         /// Internet Protocol version 4
+        TCP =   IPPROTO_TCP,        /// Transmission Control Protocol
+        UDP =   IPPROTO_UDP,        /// User Datagram Protocol
+        RAW =   IPPROTO_RAW,        /// Raw IP packets
+        IPV6 =  IPPROTO_IPV6,       /// Internet Protocol version 6
+    }
+else
+    enum ProtocolType: int
+    {
+        IP =    IPPROTO_IP,         /// Internet Protocol version 4
+        ICMP =  IPPROTO_ICMP,       /// Internet Control Message Protocol
+        IGMP =  IPPROTO_IGMP,       /// Internet Group Management Protocol
+        GGP =   IPPROTO_GGP,        /// Gateway to Gateway Protocol
+        TCP =   IPPROTO_TCP,        /// Transmission Control Protocol
+        PUP =   IPPROTO_PUP,        /// PARC Universal Packet Protocol
+        UDP =   IPPROTO_UDP,        /// User Datagram Protocol
+        IDP =   IPPROTO_IDP,        /// Xerox NS protocol
+        RAW =   IPPROTO_RAW,        /// Raw IP packets
+        IPV6 =  IPPROTO_IPV6,       /// Internet Protocol version 6
+    }
 
 
 /**
@@ -454,9 +485,10 @@ class Protocol
 }
 
 
-// Skip this test on Android because getprotobyname/number are
-// unimplemented in bionic.
+// Skip this test on Android and WASI because getprotobyname/number are
+// unimplemented in bionic and wasi-libc
 version (CRuntime_Bionic) {} else
+version (CRuntime_WASI) {} else
 @safe unittest
 {
     // import std.stdio : writefln;
@@ -779,7 +811,8 @@ class InternetHost
 }
 
 ///
-@safe unittest
+version (CRuntime_WASI) {} // gethostby* isn't implemented on WASI
+else @safe unittest
 {
     InternetHost ih = new InternetHost;
 
@@ -1114,8 +1147,13 @@ Address[] getAddress(scope const(char)[] hostname, ushort port)
 @safe unittest
 {
     softUnittest({
-        auto addresses = getAddress("63.105.9.61");
-        assert(addresses.length && addresses[0].toAddrString() == "63.105.9.61");
+        Address[] addresses;
+
+        version (CRuntime_WASI) {} // no DNS resolution in wasi-libc yet
+        else {
+            addresses = getAddress("63.105.9.61");
+            assert(addresses.length && addresses[0].toAddrString() == "63.105.9.61");
+        }
 
         if (getaddrinfoPointer)
         {
@@ -1691,42 +1729,45 @@ public:
         assert(ia.toString() == "127.0.0.1:80");
     });
 
-    softUnittest({
-        // test reverse lookup
-        auto ih = new InternetHost;
-        if (ih.getHostByName("digitalmars.com"))
-        {
-            const ia = new InternetAddress(ih.addrList[0], 80);
-            assert(ia.toHostNameString() == "digitalmars.com");
+    version (CRuntime_WASI) {} // No DNS resolution in wasi-libc yet
+    else {
+        softUnittest({
+            // test reverse lookup
+            auto ih = new InternetHost;
+            if (ih.getHostByName("digitalmars.com"))
+            {
+                const ia = new InternetAddress(ih.addrList[0], 80);
+                assert(ia.toHostNameString() == "digitalmars.com");
+
+                if (getnameinfoPointer)
+                {
+                    // test reverse lookup, via gethostbyaddr
+                    auto getnameinfoPointerBackup = getnameinfoPointer;
+                    cast() getnameinfoPointer = null;
+                    scope(exit) () @trusted { cast() getnameinfoPointer = getnameinfoPointerBackup; }();
+
+                    assert(ia.toHostNameString() == "digitalmars.com");
+                }
+            }
+        });
+
+        if (runSlowTests)
+        softUnittest({
+            // test failing reverse lookup
+            const InternetAddress ia = new InternetAddress("255.255.255.255", 80);
+            assert(ia.toHostNameString() is null);
 
             if (getnameinfoPointer)
             {
-                // test reverse lookup, via gethostbyaddr
+                // test failing reverse lookup, via gethostbyaddr
                 auto getnameinfoPointerBackup = getnameinfoPointer;
                 cast() getnameinfoPointer = null;
                 scope(exit) () @trusted { cast() getnameinfoPointer = getnameinfoPointerBackup; }();
 
-                assert(ia.toHostNameString() == "digitalmars.com");
+                assert(ia.toHostNameString() is null);
             }
-        }
-    });
-
-    if (runSlowTests)
-    softUnittest({
-        // test failing reverse lookup
-        const InternetAddress ia = new InternetAddress("255.255.255.255", 80);
-        assert(ia.toHostNameString() is null);
-
-        if (getnameinfoPointer)
-        {
-            // test failing reverse lookup, via gethostbyaddr
-            auto getnameinfoPointerBackup = getnameinfoPointer;
-            cast() getnameinfoPointer = null;
-            scope(exit) () @trusted { cast() getnameinfoPointer = getnameinfoPointerBackup; }();
-
-            assert(ia.toHostNameString() is null);
-        }
-    });
+        });
+    }
 }
 
 
@@ -1894,7 +1935,8 @@ public:
 }
 
 
-@safe unittest
+version (CRuntime_WASI) {} // No DNS resolution in wasi-libc yet
+else @safe unittest
 {
     softUnittest({
         const Internet6Address ia = new Internet6Address("::1", 80);
@@ -1970,6 +2012,11 @@ version (StdDdoc)
         override @property const(sockaddr)* name() const { return null; }
         override @property socklen_t nameLen() const { return 0; }
     }
+}
+else version (CRuntime_WASI)
+{
+    // WASI does not support UNIX domain sockets
+    // (despite defining bare-bones sockaddr_un)
 }
 else
 static if (is(sockaddr_un))
@@ -2143,15 +2190,26 @@ enum SocketShutdown: int
 
 
 /// Socket flags that may be OR'ed together:
-enum SocketFlags: int
+version (CRuntime_WASI)
 {
-    NONE =       0,                 /// no flags specified
+    enum SocketFlags: int
+    {
+        NONE =       0,                 /// no flags specified
 
-    OOB =        MSG_OOB,           /// out-of-band stream data
-    PEEK =       MSG_PEEK,          /// peek at incoming data without removing it from the queue, only for receiving
-    DONTROUTE =  MSG_DONTROUTE,     /// data should not be subject to routing; this flag may be ignored. Only for sending
+        PEEK =       MSG_PEEK,          /// peek at incoming data without removing it from the queue, only for receiving
+    }
 }
+else
+{
+    enum SocketFlags: int
+    {
+        NONE =       0,                 /// no flags specified
 
+        OOB =        MSG_OOB,           /// out-of-band stream data
+        PEEK =       MSG_PEEK,          /// peek at incoming data without removing it from the queue, only for receiving
+        DONTROUTE =  MSG_DONTROUTE,     /// data should not be subject to routing; this flag may be ignored. Only for sending
+    }
+}
 
 /// Duration timeout value.
 struct TimeVal
@@ -2227,6 +2285,64 @@ private:
             return cast(inout(socket_t)[])set[FD_SET_OFFSET .. FD_SET_OFFSET+count];
         }
     }
+    else version (CRuntime_WASI)
+    {
+        // On WASI, fd_set is an array of socket handles,
+        // following a size_t containing the fd_set instance size.
+        // We use one dynamic array for everything, and use its first
+        // element(s) for the count.
+        alias fd_set_count_type = typeof(fd_set.init.__nfds);
+        alias fd_set_type = typeof(fd_set.init.__fds[0]);
+        static assert(fd_set_type.sizeof == socket_t.sizeof);
+
+        // Number of fd_set_type elements at the start of our array that are
+        // used for the socket count and alignment
+
+        enum FD_SET_OFFSET = fd_set.__fds.offsetof / fd_set_type.sizeof;
+        static assert(FD_SET_OFFSET);
+        static assert(fd_set.__nfds.offsetof % fd_set_type.sizeof == 0);
+
+        fd_set_type[] set;
+
+        void resize(size_t size) pure nothrow
+        {
+            set.length = FD_SET_OFFSET + size;
+        }
+
+        // Make sure we can fit that many sockets
+
+        void setMinCapacity(size_t size) pure nothrow
+        {
+            auto length = lengthFor(size);
+            if (set.length < length)
+                set.length = length;
+        }
+
+        // Array size to fit that many sockets
+
+        static size_t lengthFor(size_t size) pure nothrow @nogc
+        {
+            return (size + (fd_set.__fds.length - 1)) / fd_set.__fds.length;
+        }
+
+        ref inout(fd_set_count_type) count() @trusted @property inout pure nothrow @nogc
+        {
+            assert(set.length);
+            return *cast(inout(fd_set_count_type)*)set.ptr;
+        }
+
+        size_t capacity() @property const pure nothrow @nogc
+        {
+            return set.length - FD_SET_OFFSET;
+        }
+
+        inout(socket_t)[] fds() @trusted inout @property pure nothrow @nogc
+        {
+            return cast(inout(socket_t)[])set[FD_SET_OFFSET .. FD_SET_OFFSET+count];
+        }
+
+        int maxfd;
+    }
     else
     version (Posix)
     {
@@ -2301,6 +2417,11 @@ public:
     {
         version (Windows)
             count = 0;
+        else version (CRuntime_WASI)
+        {
+            count = 0;
+            maxfd = -1;
+        }
         else
         {
             set[] = 0;
@@ -2320,6 +2441,20 @@ public:
             }
             ++count;
             fds[$-1] = s;
+        }
+        else version (CRuntime_WASI)
+        {
+            //assert(s != null);
+            if (count == capacity)
+            {
+                set.length *= 2;
+                set.length = set.capacity;
+            }
+            ++count;
+            fds[$-1] = s;
+
+            if (maxfd < s)
+                maxfd = s;
         }
         else
         {
@@ -2357,6 +2492,15 @@ public:
             if (p >= 0)
                 fds[p] = fds[--count];
         }
+        else version (CRuntime_WASI)
+        {
+            import std.algorithm.searching : countUntil;
+            auto fds = fds;
+            auto p = fds.countUntil(s);
+            if (p >= 0)
+                fds[p] = fds[--count];
+            // note: adjusting maxfd would require scanning the set, not worth it
+        }
         else
         {
             auto index = s / FD_NFDBITS;
@@ -2381,6 +2525,13 @@ public:
     {
         version (Windows)
         {
+            import std.algorithm.searching : canFind;
+            return fds.canFind(s) ? 1 : 0;
+        }
+        else version (CRuntime_WASI)
+        {
+            if (s > maxfd)
+                return 0;
             import std.algorithm.searching : canFind;
             return fds.canFind(s) ? 1 : 0;
         }
@@ -2458,7 +2609,13 @@ public:
     }
 }
 
-@safe unittest
+version (CRuntime_WASI) {
+    // Some strange bug(?) where `select` read availability becomes sticky
+    // after the first send, after even `recv`ing the data.
+    //
+    // Also, a very low limit on the number of pairs that can be reliably polled???
+}
+else @safe unittest
 {
     version (iOSDerived)
     {
@@ -2472,7 +2629,8 @@ public:
     }
 
     softUnittest({
-        version (Posix)
+        version (CRuntime_WASI) {}
+        else version (Posix)
         () @trusted
         {
             static assert(LIMIT > PAIRS*2);
@@ -2564,19 +2722,34 @@ public:
 }
 
 /// The level at which a socket option is defined:
-enum SocketOptionLevel: int
+version (CRuntime_WASI)
 {
-    SOCKET =  SOL_SOCKET,               /// Socket level
-    IP =      ProtocolType.IP,          /// Internet Protocol version 4 level
-    ICMP =    ProtocolType.ICMP,        /// Internet Control Message Protocol level
-    IGMP =    ProtocolType.IGMP,        /// Internet Group Management Protocol level
-    GGP =     ProtocolType.GGP,         /// Gateway to Gateway Protocol level
-    TCP =     ProtocolType.TCP,         /// Transmission Control Protocol level
-    PUP =     ProtocolType.PUP,         /// PARC Universal Packet Protocol level
-    UDP =     ProtocolType.UDP,         /// User Datagram Protocol level
-    IDP =     ProtocolType.IDP,         /// Xerox NS protocol level
-    RAW =     ProtocolType.RAW,         /// Raw IP packet level
-    IPV6 =    ProtocolType.IPV6,        /// Internet Protocol version 6 level
+    enum SocketOptionLevel: int
+    {
+        SOCKET =  SOL_SOCKET,               /// Socket level
+        IP =      ProtocolType.IP,          /// Internet Protocol version 4 level
+        TCP =     ProtocolType.TCP,         /// Transmission Control Protocol level
+        UDP =     ProtocolType.UDP,         /// User Datagram Protocol level
+        RAW =     ProtocolType.RAW,         /// Raw IP packet level
+        IPV6 =    ProtocolType.IPV6,        /// Internet Protocol version 6 level
+    }
+}
+else
+{
+    enum SocketOptionLevel: int
+    {
+        SOCKET =  SOL_SOCKET,               /// Socket level
+        IP =      ProtocolType.IP,          /// Internet Protocol version 4 level
+        ICMP =    ProtocolType.ICMP,        /// Internet Control Message Protocol level
+        IGMP =    ProtocolType.IGMP,        /// Internet Group Management Protocol level
+        GGP =     ProtocolType.GGP,         /// Gateway to Gateway Protocol level
+        TCP =     ProtocolType.TCP,         /// Transmission Control Protocol level
+        PUP =     ProtocolType.PUP,         /// PARC Universal Packet Protocol level
+        UDP =     ProtocolType.UDP,         /// User Datagram Protocol level
+        IDP =     ProtocolType.IDP,         /// Xerox NS protocol level
+        RAW =     ProtocolType.RAW,         /// Raw IP packet level
+        IPV6 =    ProtocolType.IPV6,        /// Internet Protocol version 6 level
+    }
 }
 
 /// _Linger information for use with SocketOption.LINGER.
@@ -2603,54 +2776,84 @@ struct Linger
 }
 
 /// Specifies a socket option:
-enum SocketOption: int
+version (CRuntime_WASI)
 {
-    DEBUG =                SO_DEBUG,            /// Record debugging information
-    BROADCAST =            SO_BROADCAST,        /// Allow transmission of broadcast messages
-    REUSEADDR =            SO_REUSEADDR,        /// Allow local reuse of address
-    /**
-     * Allow local reuse of port
-     *
-     * On Windows, this is equivalent to `SocketOption.REUSEADDR`.
-     * There is in fact no option named `REUSEPORT`.
-     * However, `SocketOption.REUSEADDR` matches the behavior of
-     * `SocketOption.REUSEPORT` on other platforms. Further details on this
-     * topic can be found here:
-     * $(LINK https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse)
-     *
-     * On Linux, this ensures fair distribution of incoming connections accross threads.
-     *
-     * See_Also:
-     *   https://lwn.net/Articles/542629/
-     */
-    REUSEPORT =            SO_REUSEPORT,
-    LINGER =               SO_LINGER,           /// Linger on close if unsent data is present
-    OOBINLINE =            SO_OOBINLINE,        /// Receive out-of-band data in band
-    SNDBUF =               SO_SNDBUF,           /// Send buffer size
-    RCVBUF =               SO_RCVBUF,           /// Receive buffer size
-    DONTROUTE =            SO_DONTROUTE,        /// Do not route
-    SNDTIMEO =             SO_SNDTIMEO,         /// Send timeout
-    RCVTIMEO =             SO_RCVTIMEO,         /// Receive timeout
-    ERROR =                SO_ERROR,            /// Retrieve and clear error status
-    KEEPALIVE =            SO_KEEPALIVE,        /// Enable keep-alive packets
-    ACCEPTCONN =           SO_ACCEPTCONN,       /// Listen
-    RCVLOWAT =             SO_RCVLOWAT,         /// Minimum number of input bytes to process
-    SNDLOWAT =             SO_SNDLOWAT,         /// Minimum number of output bytes to process
-    TYPE =                 SO_TYPE,             /// Socket type
+    enum SocketOption: int
+    {
+        REUSEADDR =            SO_REUSEADDR,        /// Allow local reuse of address
 
-    // SocketOptionLevel.TCP:
-    TCP_NODELAY =          .TCP_NODELAY,        /// Disable the Nagle algorithm for send coalescing
+        SNDBUF =               SO_SNDBUF,           /// Send buffer size
+        RCVBUF =               SO_RCVBUF,           /// Receive buffer size
+        SNDTIMEO =             SO_SNDTIMEO,         /// Send timeout
+        RCVTIMEO =             SO_RCVTIMEO,         /// Receive timeout
+        ERROR =                SO_ERROR,            /// Retrieve and clear error status
+        KEEPALIVE =            SO_KEEPALIVE,        /// Enable keep-alive packets
+        ACCEPTCONN =           SO_ACCEPTCONN,       /// Listen
+        TYPE =                 SO_TYPE,             /// Socket type
 
-    // SocketOptionLevel.IPV6:
-    IPV6_UNICAST_HOPS =    .IPV6_UNICAST_HOPS,          /// IP unicast hop limit
-    IPV6_MULTICAST_IF =    .IPV6_MULTICAST_IF,          /// IP multicast interface
-    IPV6_MULTICAST_LOOP =  .IPV6_MULTICAST_LOOP,        /// IP multicast loopback
-    IPV6_MULTICAST_HOPS =  .IPV6_MULTICAST_HOPS,        /// IP multicast hops
-    IPV6_JOIN_GROUP =      .IPV6_JOIN_GROUP,            /// Add an IP group membership
-    IPV6_LEAVE_GROUP =     .IPV6_LEAVE_GROUP,           /// Drop an IP group membership
-    IPV6_V6ONLY =          .IPV6_V6ONLY,                /// Treat wildcard bind as AF_INET6-only
+        // SocketOptionLevel.TCP:
+        TCP_NODELAY =          .TCP_NODELAY,        /// Disable the Nagle algorithm for send coalescing
+
+        // SocketOptionLevel.IPV6:
+        IPV6_UNICAST_HOPS =    .IPV6_UNICAST_HOPS,          /// IP unicast hop limit
+        IPV6_MULTICAST_IF =    .IPV6_MULTICAST_IF,          /// IP multicast interface
+        IPV6_MULTICAST_LOOP =  .IPV6_MULTICAST_LOOP,        /// IP multicast loopback
+        IPV6_MULTICAST_HOPS =  .IPV6_MULTICAST_HOPS,        /// IP multicast hops
+        IPV6_JOIN_GROUP =      .IPV6_JOIN_GROUP,            /// Add an IP group membership
+        IPV6_LEAVE_GROUP =     .IPV6_LEAVE_GROUP,           /// Drop an IP group membership
+        IPV6_V6ONLY =          .IPV6_V6ONLY,                /// Treat wildcard bind as AF_INET6-only
+    }
 }
+else
+{
+    enum SocketOption: int
+    {
+        DEBUG =                SO_DEBUG,            /// Record debugging information
+        BROADCAST =            SO_BROADCAST,        /// Allow transmission of broadcast messages
+        REUSEADDR =            SO_REUSEADDR,        /// Allow local reuse of address
+        /**
+        * Allow local reuse of port
+        *
+        * On Windows, this is equivalent to `SocketOption.REUSEADDR`.
+        * There is in fact no option named `REUSEPORT`.
+        * However, `SocketOption.REUSEADDR` matches the behavior of
+        * `SocketOption.REUSEPORT` on other platforms. Further details on this
+        * topic can be found here:
+        * $(LINK https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse)
+        *
+        * On Linux, this ensures fair distribution of incoming connections accross threads.
+        *
+        * See_Also:
+        *   https://lwn.net/Articles/542629/
+        */
+        REUSEPORT =            SO_REUSEPORT,
+        LINGER =               SO_LINGER,           /// Linger on close if unsent data is present
+        OOBINLINE =            SO_OOBINLINE,        /// Receive out-of-band data in band
+        SNDBUF =               SO_SNDBUF,           /// Send buffer size
+        RCVBUF =               SO_RCVBUF,           /// Receive buffer size
+        DONTROUTE =            SO_DONTROUTE,        /// Do not route
+        SNDTIMEO =             SO_SNDTIMEO,         /// Send timeout
+        RCVTIMEO =             SO_RCVTIMEO,         /// Receive timeout
+        ERROR =                SO_ERROR,            /// Retrieve and clear error status
+        KEEPALIVE =            SO_KEEPALIVE,        /// Enable keep-alive packets
+        ACCEPTCONN =           SO_ACCEPTCONN,       /// Listen
+        RCVLOWAT =             SO_RCVLOWAT,         /// Minimum number of input bytes to process
+        SNDLOWAT =             SO_SNDLOWAT,         /// Minimum number of output bytes to process
+        TYPE =                 SO_TYPE,             /// Socket type
 
+        // SocketOptionLevel.TCP:
+        TCP_NODELAY =          .TCP_NODELAY,        /// Disable the Nagle algorithm for send coalescing
+
+        // SocketOptionLevel.IPV6:
+        IPV6_UNICAST_HOPS =    .IPV6_UNICAST_HOPS,          /// IP unicast hop limit
+        IPV6_MULTICAST_IF =    .IPV6_MULTICAST_IF,          /// IP multicast interface
+        IPV6_MULTICAST_LOOP =  .IPV6_MULTICAST_LOOP,        /// IP multicast loopback
+        IPV6_MULTICAST_HOPS =  .IPV6_MULTICAST_HOPS,        /// IP multicast hops
+        IPV6_JOIN_GROUP =      .IPV6_JOIN_GROUP,            /// Add an IP group membership
+        IPV6_LEAVE_GROUP =     .IPV6_LEAVE_GROUP,           /// Drop an IP group membership
+        IPV6_V6ONLY =          .IPV6_V6ONLY,                /// Treat wildcard bind as AF_INET6-only
+    }
+}
 
 /**
  * Class that creates a network communication endpoint using
@@ -3593,7 +3796,8 @@ public:
         Address result;
         switch (_family)
         {
-        static if (is(sockaddr_un))
+        version (CRuntime_WASI) {} // No UNIX sockets, despite `sockaddr_un`
+        else static if (is(sockaddr_un))
         {
             case AddressFamily.UNIX:
                 result = new UnixAddress;
@@ -3849,7 +4053,25 @@ class UdpSocket: Socket
  */
 Socket[2] socketPair() @trusted
 {
-    version (Posix)
+    version (CRuntime_WASI)
+    {
+        // We do not have socketpair() on WASI, just manually create a
+        // pair of sockets connected over some localhost port.
+        Socket[2] result;
+
+        auto listener = new TcpSocket();
+        listener.setOption(SocketOptionLevel.SOCKET, SocketOption.REUSEADDR, true);
+        listener.bind(new InternetAddress(INADDR_LOOPBACK, InternetAddress.PORT_ANY));
+        auto addr = listener.localAddress;
+        listener.listen(1);
+
+        result[0] = new TcpSocket(addr);
+        result[1] = listener.accept();
+
+        listener.close();
+        return result;
+    }
+    else version (Posix)
     {
         int[2] socks;
         if (socketpair(AF_UNIX, SOCK_STREAM, 0, socks) == -1)

--- a/std/stdio.d
+++ b/std/stdio.d
@@ -135,6 +135,10 @@ else version (CRuntime_Musl)
 {
     version = GENERIC_IO;
 }
+else version (CRuntime_WASI)
+{
+    version = GENERIC_IO;
+}
 else version (CRuntime_UClibc)
 {
     version = GENERIC_IO;
@@ -246,7 +250,13 @@ else version (GENERIC_IO)
         pragma(mangle, core.stdc.wchar_.fgetwc.mangleof) int _FGETWC(_iobuf* fp);
     }
 
-    version (Posix)
+    version (CRuntime_WASI)
+    {
+        // no file locking/unlocking at the moment
+        private extern(D) void _FLOCK(FILE*) {}
+        private extern(D) void _FUNLOCK(FILE*) {}
+    }
+    else version (Posix)
     {
         private alias _FLOCK = core.sys.posix.stdio.flockfile;
         private alias _FUNLOCK = core.sys.posix.stdio.funlockfile;
@@ -545,7 +555,14 @@ Throws: `ErrnoException` in case of error.
         }
 
         FILE* handle;
-        version (Posix)
+        version (CRuntime_WASI) // wasi-libc has no preopens
+        {
+            assert(isPopened == false);
+            errnoEnforce(handle = _fopen(name, stdioOpenmode),
+                         text("Cannot open file `", name, "' in mode `",
+                              stdioOpenmode, "'"));
+        }
+        else version (Posix)
         {
             if (isPopened)
             {
@@ -579,7 +596,8 @@ Throws: `ErrnoException` in case of error.
         assert(_p);
         import std.exception : errnoEnforce;
 
-        version (Posix)
+        version (CRuntime_WASI) {} // wasi-libc has no pclose
+        else version (Posix)
         {
             import core.sys.posix.stdio : pclose;
             import std.format : format;
@@ -2181,7 +2199,8 @@ EOF
 /**
  Returns a temporary file by calling $(CSTDIO tmpfile).
  Note that the created file has no $(LREF name).*/
-    static File tmpfile() @safe
+    version (CRuntime_WASI) {}
+    else static File tmpfile() @safe
     {
         import std.exception : errnoEnforce;
 
@@ -2730,6 +2749,15 @@ $(REF readText, std,file)
             /* the C function tmpfile doesn't work when called from a shared
                library apk:
                https://code.google.com/p/android/issues/detail?id=66815 */
+            auto deleteme = testFilename();
+            auto file = File(deleteme, "w+");
+            scope(success) std.file.remove(deleteme);
+        }
+        else version (CRuntime_WASI)
+        {
+            static import std.file;
+
+            /* wasi-libc has no tmpfile */
             auto deleteme = testFilename();
             auto file = File(deleteme, "w+");
             scope(success) std.file.remove(deleteme);

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3550,7 +3550,8 @@ if (is(T == class) || is(T == interface))
 }
 
 ///
-@system unittest
+version (WASI) {} // WASI is single-threaded
+else @system unittest
 {
     class Data {}
 

--- a/std/typecons.d
+++ b/std/typecons.d
@@ -3550,26 +3550,30 @@ if (is(T == class) || is(T == interface))
 }
 
 ///
-version (WASI) {} // WASI is single-threaded
-else @system unittest
+@system unittest
 {
     class Data {}
 
     static shared(Data) a;
     static UnqualRef!(shared Data) b;
 
-    import core.thread;
 
-    auto thread = new core.thread.Thread({
-        a = new shared Data();
-        b = new shared Data();
-    });
+    version (WASI) {} // WASI is single-threaded
+    else
+    {
+        import core.thread;
 
-    thread.start();
-    thread.join();
+        auto thread = new core.thread.Thread({
+            a = new shared Data();
+            b = new shared Data();
+        });
 
-    assert(a !is null);
-    assert(b is null);
+        thread.start();
+        thread.join();
+
+        assert(a !is null);
+        assert(b is null);
+    }
 }
 
 @safe unittest

--- a/std/zip.d
+++ b/std/zip.d
@@ -114,12 +114,13 @@ module std.zip;
 
 import std.exception : enforce;
 
-// Non-Android/Apple ARM POSIX-only, because we can't rely on the unzip
-// command being available on Android, Apple ARM or Windows
+// Non-Android/Apple ARM/WASI POSIX-only, because we can't rely on the unzip
+// command being available on Android, Apple ARM, Windows, or WASI
 version (Android) {}
 else version (iOS) {}
 else version (TVOS) {}
 else version (WatchOS) {}
+else version (WASI) {}
 else version (Posix)
     version = HasUnzip;
 


### PR DESCRIPTION
## Rationale

Adds support for WASI (p1 & p2; wasi-libc) to Phobos. This builds on prior work done in DRuntime to support the same targets (largely using `wasi-libc`'s POSIX emulation).

## Pre-review checklist

- [x] I have performed a self-review of my code.
  - This code has also already been reviewed and merged in LDC by @kinke. This is a cherry-pick of the changes. I checked that there are no faulty conflict resolutions, but did NOT verify that support is 100% complete with anything new `master` Phobos may have added.
- [x] If my PR fixes a bug or introduces a new feature, I have added thorough tests.
  - No new tests are added to Phobos, but the existing unittests are run during LDC CI for both WASIp1 and WASIp2 targets.
- [ ] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.
  - I did NOT add an entry, as these changes do not impact upstream DMD's Phobos, and are only visible in LDC.