### PR TITLE
Fix #9824: allocator.dispose for qualified array types

### DIFF
--- a/std/experimental/allocator/package.d
+++ b/std/experimental/allocator/package.d
@@ -2454,7 +2454,7 @@ void dispose(A, T)(auto ref A alloc, auto ref T[] array)
             destroy(e);
         }
     }
-    alloc.deallocate(array);
+    alloc.deallocate(cast(void[]) array);
     static if (__traits(isRef, array))
         array = null;
 }
@@ -2495,6 +2495,20 @@ void dispose(A, T)(auto ref A alloc, auto ref T[] array)
 
     int[] arr = theAllocator.makeArray!int(43);
     theAllocator.dispose(arr);
+}
+
+// https://github.com/dlang/phobos/issues/9824
+@system unittest
+{
+    import std.experimental.allocator.mallocator : Mallocator;
+
+    const(int)[] ci = Mallocator.instance.makeArray!int(10);
+    Mallocator.instance.dispose(ci);
+    assert(ci is null);
+
+    immutable(int)[] ii = cast(immutable(int)[]) Mallocator.instance.makeArray!int(10);
+    Mallocator.instance.dispose(ii);
+    assert(ii is null);
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=16512


### PR DESCRIPTION
## Rationale

### Feature request or issue tracking

Closes #9824.

## Pre-review checklist

- [x] I have performed a self-review of my code.
- [x] If my PR fixes a bug or introduces a new feature, I have added thorough tests.
- [x] If my changes are non-trivial and do not concern a reported issue, I have added a changelog entry.