### PR TITLE
conv to unsigned: no check required

### DIFF
--- a/std/conv.d
+++ b/std/conv.d
@@ -5585,7 +5585,7 @@ if (isIntegral!T && isOutputRange!(W, char))
     else
     {
         UnsignedStringBuf buf = void;
-        put(writer, unsignedToTempString(value.unsigned, buf));
+        put(writer, unsignedToTempString(cast(Unsigned!T)value, buf));
     }
 }
 
@@ -6108,7 +6108,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
 
                 char[] t = value < 0
                     ?   signedToTempString!(10, false, char)(value, buf)
-                    : unsignedToTempString!(10, false, char)(value.unsigned, buf);
+                    : unsignedToTempString!(10, false, char)(cast(Unsigned!UT)value, buf);
 
                 lwr = cast(uint) (buf.length - t.length);
                 upr = cast(uint) buf.length;

--- a/std/conv.d
+++ b/std/conv.d
@@ -5585,7 +5585,7 @@ if (isIntegral!T && isOutputRange!(W, char))
     else
     {
         UnsignedStringBuf buf = void;
-        put(writer, unsignedToTempString(cast(Unsigned!T)value, buf));
+        put(writer, unsignedToTempString(cast(Unsigned!T) value, buf));
     }
 }
 

--- a/std/conv.d
+++ b/std/conv.d
@@ -6108,7 +6108,7 @@ if ((radix == 2 || radix == 8 || radix == 10 || radix == 16) &&
 
                 char[] t = value < 0
                     ?   signedToTempString!(10, false, char)(value, buf)
-                    : unsignedToTempString!(10, false, char)(cast(Unsigned!UT)value, buf);
+                    : unsignedToTempString!(10, false, char)(cast(Unsigned!UT) value, buf);
 
                 lwr = cast(uint) (buf.length - t.length);
                 upr = cast(uint) buf.length;


### PR DESCRIPTION
## Rationale

#11082 added unnecessary checks here. We already sure that `value` is not negative, so it is safe to use cast here

- [x] I have performed a self-review of my code.
