### PR TITLE
Remove `LINUX_LEGACY_EMULATE_GETRANDOM` option from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,10 +173,6 @@ ifdef NO_AUTODECODE
 override DFLAGS += -version=NoAutodecodeStrings
 endif
 
-ifdef LINUX_LEGACY_EMULATE_GETRANDOM
-override DFLAGS += -version=linux_legacy_emulate_getrandom
-endif
-
 UDFLAGS=-unittest -version=StdUnittest
 
 LINKDL:=$(if $(findstring $(OS),linux),-L-ldl,)


### PR DESCRIPTION
## Rationale

The code that was enabled by this flag is long gone. It was only ever available as a patch release.
This basically cleans up a leftover flag that accidentally made it through a stable-into-master merge.


### Feature request or issue tracking

*n/a*


## Pre-review checklist

- [x] I have performed a self-review of my code.

### LLM/AI disclosure

Do you really think I’d need an LLM for that?
